### PR TITLE
Include mouse settings

### DIFF
--- a/Swift Shift.xcodeproj/project.pbxproj
+++ b/Swift Shift.xcodeproj/project.pbxproj
@@ -11,9 +11,7 @@
 		173C0E832C123CF700654527 /* DrawCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173C0E822C123CF700654527 /* DrawCircle.swift */; };
 		174652CE2B33345200241CE6 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174652CD2B33345200241CE6 /* WindowManager.swift */; };
 		177FB2412B31F9B900B11BA3 /* PermissionsRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177FB2402B31F9B900B11BA3 /* PermissionsRequestView.swift */; };
-		177FB2482B31FE7F00B11BA3 /* ShortcutRecorder in Frameworks */ = {isa = PBXBuildFile; productRef = 177FB2472B31FE7F00B11BA3 /* ShortcutRecorder */; };
 		177FB24C2B31FF1E00B11BA3 /* ShortcutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177FB24B2B31FF1E00B11BA3 /* ShortcutView.swift */; };
-		177FB24E2B32131600B11BA3 /* ShortcutRecorder in Frameworks */ = {isa = PBXBuildFile; productRef = 177FB24D2B32131600B11BA3 /* ShortcutRecorder */; };
 		177FB2512B32160B00B11BA3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177FB2502B32160B00B11BA3 /* AppDelegate.swift */; };
 		177FB2532B321D0500B11BA3 /* ShortcutsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177FB2522B321D0500B11BA3 /* ShortcutsManager.swift */; };
 		1781A5E22B31EE4A00F27910 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1781A5E12B31EE4A00F27910 /* App.swift */; };
@@ -22,10 +20,12 @@
 		1781A5E92B31EE4B00F27910 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1781A5E82B31EE4B00F27910 /* Preview Assets.xcassets */; };
 		1798B1202B4812D600E07964 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1798B11F2B4812D600E07964 /* SettingsView.swift */; };
 		1798B1222B48131400E07964 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1798B1212B48131400E07964 /* InfoView.swift */; };
-		17F33F2A2B37026400F85E01 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 17F33F292B37026400F85E01 /* LaunchAtLogin */; };
+		336441112C189812000A1C90 /* CGEventSupervisor in Frameworks */ = {isa = PBXBuildFile; productRef = 336441102C189812000A1C90 /* CGEventSupervisor */; };
+		338FBF5B2C1855AE00D1ECA6 /* ShortcutRecorder in Frameworks */ = {isa = PBXBuildFile; productRef = 338FBF5A2C1855AE00D1ECA6 /* ShortcutRecorder */; };
+		338FBF5D2C1855B200D1ECA6 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 338FBF5C2C1855B200D1ECA6 /* LaunchAtLogin */; };
+		338FBF5F2C1855B400D1ECA6 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 338FBF5E2C1855B400D1ECA6 /* Sparkle */; };
 		E236331E2B44669200C0E61F /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = E236331D2B44669200C0E61F /* Preferences.swift */; };
 		E23633202B4466F800C0E61F /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E236331F2B4466F800C0E61F /* PreferencesView.swift */; };
-		E23633232B44749C00C0E61F /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = E23633222B44749C00C0E61F /* Sparkle */; };
 		E2CABBA52B447AEA00D66D43 /* UpdatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CABBA42B447AEA00D66D43 /* UpdatesView.swift */; };
 		E2CABBA82B44D69B00D66D43 /* UpdatesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CABBA72B44D69B00D66D43 /* UpdatesManager.swift */; };
 		E2D8CFB92B3C3B9B00EBB047 /* PermissionsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D8CFB82B3C3B9B00EBB047 /* PermissionsManager.swift */; };
@@ -61,10 +61,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				17F33F2A2B37026400F85E01 /* LaunchAtLogin in Frameworks */,
-				E23633232B44749C00C0E61F /* Sparkle in Frameworks */,
-				177FB24E2B32131600B11BA3 /* ShortcutRecorder in Frameworks */,
-				177FB2482B31FE7F00B11BA3 /* ShortcutRecorder in Frameworks */,
+				338FBF5F2C1855B400D1ECA6 /* Sparkle in Frameworks */,
+				338FBF5D2C1855B200D1ECA6 /* LaunchAtLogin in Frameworks */,
+				338FBF5B2C1855AE00D1ECA6 /* ShortcutRecorder in Frameworks */,
+				336441112C189812000A1C90 /* CGEventSupervisor in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -211,10 +211,10 @@
 			);
 			name = "Swift Shift";
 			packageProductDependencies = (
-				177FB2472B31FE7F00B11BA3 /* ShortcutRecorder */,
-				177FB24D2B32131600B11BA3 /* ShortcutRecorder */,
-				17F33F292B37026400F85E01 /* LaunchAtLogin */,
-				E23633222B44749C00C0E61F /* Sparkle */,
+				338FBF5A2C1855AE00D1ECA6 /* ShortcutRecorder */,
+				338FBF5C2C1855B200D1ECA6 /* LaunchAtLogin */,
+				338FBF5E2C1855B400D1ECA6 /* Sparkle */,
+				336441102C189812000A1C90 /* CGEventSupervisor */,
 			);
 			productName = "Swift Shift";
 			productReference = 1781A5DE2B31EE4900F27910 /* Swift Shift.app */;
@@ -248,6 +248,7 @@
 				177FB2462B31FE7F00B11BA3 /* XCRemoteSwiftPackageReference "ShortcutRecorder" */,
 				17F33F282B37026400F85E01 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
 				E23633212B44749C00C0E61F /* XCRemoteSwiftPackageReference "Sparkle" */,
+				3364410F2C189812000A1C90 /* XCRemoteSwiftPackageReference "CGEventSupervisor" */,
 			);
 			productRefGroup = 1781A5DF2B31EE4900F27910 /* Products */;
 			projectDirPath = "";
@@ -524,6 +525,14 @@
 				kind = branch;
 			};
 		};
+		3364410F2C189812000A1C90 /* XCRemoteSwiftPackageReference "CGEventSupervisor" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/stephancasas/CGEventSupervisor";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		E23633212B44749C00C0E61F /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
@@ -535,22 +544,22 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		177FB2472B31FE7F00B11BA3 /* ShortcutRecorder */ = {
+		336441102C189812000A1C90 /* CGEventSupervisor */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3364410F2C189812000A1C90 /* XCRemoteSwiftPackageReference "CGEventSupervisor" */;
+			productName = CGEventSupervisor;
+		};
+		338FBF5A2C1855AE00D1ECA6 /* ShortcutRecorder */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 177FB2462B31FE7F00B11BA3 /* XCRemoteSwiftPackageReference "ShortcutRecorder" */;
 			productName = ShortcutRecorder;
 		};
-		177FB24D2B32131600B11BA3 /* ShortcutRecorder */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 177FB2462B31FE7F00B11BA3 /* XCRemoteSwiftPackageReference "ShortcutRecorder" */;
-			productName = ShortcutRecorder;
-		};
-		17F33F292B37026400F85E01 /* LaunchAtLogin */ = {
+		338FBF5C2C1855B200D1ECA6 /* LaunchAtLogin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 17F33F282B37026400F85E01 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */;
 			productName = LaunchAtLogin;
 		};
-		E23633222B44749C00C0E61F /* Sparkle */ = {
+		338FBF5E2C1855B400D1ECA6 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E23633212B44749C00C0E61F /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;

--- a/Swift Shift/src/app/SettingsView.swift
+++ b/Swift Shift/src/app/SettingsView.swift
@@ -34,6 +34,7 @@ struct SettingsView: View {
                     VStack {
                         ForEach(Array(ShortcutType.allCases), id: \.self) { type in
                             ShortcutView(type: type)
+                                .padding(.vertical, 6)
                         }
                     }
                 } else {

--- a/Swift Shift/src/mouse/MouseTracker.swift
+++ b/Swift Shift/src/mouse/MouseTracker.swift
@@ -12,8 +12,6 @@ enum Quadrant {
 }
 
 class MouseTracker {
-    static let MOUSE_EVENT_SUBSCRIBER = "MouseTracker_mouseMoved"
-
     static let shared = MouseTracker()
     private var mouseEventMonitor: Any?
     private var initialMouseLocation: NSPoint?

--- a/Swift Shift/src/shortchuts/ShortcutView.swift
+++ b/Swift Shift/src/shortchuts/ShortcutView.swift
@@ -16,7 +16,7 @@ struct ShortcutNSView: NSViewRepresentable {
         nsView.objectValue = shortcut
         nsView.translatesAutoresizingMaskIntoConstraints = false
         
-        // Force width/height 
+        // Force width/height
         //        NSLayoutConstraint.activate([
         //            nsView.widthAnchor.constraint(equalToConstant: 100),
         //            nsView.heightAnchor.constraint(equalToConstant: 20)
@@ -42,30 +42,88 @@ struct ShortcutNSView: NSViewRepresentable {
 
 struct ShortcutView: View {
     @State private var shortcut: UserShortcut
+    @State private var isExpanded: Bool
+    @State private var requireMouseClick: Bool
     
     init(type: ShortcutType) {
-        self.shortcut = ShortcutsManager.shared.load(for: type) ?? UserShortcut(type: type)
+        let loadedShortcut = ShortcutsManager.shared.load(for: type) ?? UserShortcut(type: type, mouseButton: .none)
+        self.shortcut = loadedShortcut
+        self.requireMouseClick = loadedShortcut.mouseButton != MouseButton.none
+        self.isExpanded = loadedShortcut.mouseButton != MouseButton.none
     }
     
     var body: some View {
-        HStack {
-            Text(shortcut.type.rawValue).frame(width: 60, alignment: .leading)
-            ShortcutNSView(shortcut: $shortcut.shortcut)
-                .onChange(of: shortcut.shortcut, perform: {
-                    newValue in
-                    if (newValue == nil) {
-                        ShortcutsManager.shared.delete(for: shortcut.type)
-                    } else {
+        VStack(alignment: .leading) {
+            HStack {
+                Text(shortcut.type.rawValue)
+                    .font(.headline)
+                    .frame(width: 60, alignment: .leading)
+                ShortcutNSView(shortcut: $shortcut.shortcut)
+                    .onChange(of: shortcut.shortcut, perform: {
+                        newValue in
+                        if (newValue == nil) {
+                            ShortcutsManager.shared.delete(for: shortcut.type)
+                        } else {
+                            ShortcutsManager.shared.save(shortcut)
+                        }
+                    })
+                Button("Clear") {
+                    shortcut.shortcut = nil
+                }
+                Button(action: {
+                    withAnimation(.easeIn(duration: 0.3)) {
+                        isExpanded.toggle()
+                    }
+                }) {
+                    Image(systemName: "chevron.right")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 10, height: 10)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }.buttonStyle(.borderless)
+            }
+            if isExpanded {
+                HStack {
+                    Toggle(isOn: $requireMouseClick, label: {
+                        Text("Require mouse click")
+                    }).onChange(of: requireMouseClick) {
+                        newValue in
+                        if (newValue == false) {
+                            shortcut.mouseButton = MouseButton.none
+                        } else {
+                            shortcut.mouseButton = MouseButton.left
+                        }
                         ShortcutsManager.shared.save(shortcut)
                     }
-                })
-            Button("Clear") {
-                shortcut.shortcut = nil
+                    
+                    if requireMouseClick {
+                        
+                        Spacer()
+                        
+                        Image(systemName: "magicmouse.fill")
+                        
+                        Picker("", selection: $shortcut.mouseButton) {
+                            ForEach(Array(MouseButton.allCases), id: \.self) { type in
+                                Text(type.rawValue).tag(type)
+                            }
+                        }.onChange(of: shortcut.mouseButton) {
+                            newValue in
+                            if (newValue == .none) {
+                                requireMouseClick = false
+                            }
+                        }
+                        .frame(width: 100).padding(.leading, -10)
+                    }
+                }
+                .animation(.easeInOut, value: isExpanded)
             }
+            
         }
     }
 }
 
 #Preview {
     ShortcutView(type: .move)
+        .padding()
+        .frame(width: MAIN_WINDOW_WIDTH)
 }

--- a/Swift Shift/src/shortchuts/ShortcutView.swift
+++ b/Swift Shift/src/shortchuts/ShortcutView.swift
@@ -111,6 +111,7 @@ struct ShortcutView: View {
                             if (newValue == .none) {
                                 requireMouseClick = false
                             }
+                            ShortcutsManager.shared.save(shortcut)
                         }
                         .frame(width: 100).padding(.leading, -10)
                     }

--- a/Swift Shift/src/shortchuts/ShortcutsManager.swift
+++ b/Swift Shift/src/shortchuts/ShortcutsManager.swift
@@ -5,9 +5,22 @@ enum ShortcutType: String, CaseIterable {
     case resize = "Resize"
 }
 
+enum MouseButton: String, CaseIterable {
+    case none = "None"
+    case left = "Left"
+    case right = "Right"
+}
+
 struct UserShortcut {
     var type: ShortcutType
     var shortcut: Shortcut?
+    var mouseButton: MouseButton
+    
+    init(type: ShortcutType, shortcut: Shortcut? = nil, mouseButton: MouseButton) {
+        self.type = type
+        self.shortcut = shortcut
+        self.mouseButton = mouseButton
+    }
 }
 
 class ShortcutsManager {
@@ -34,7 +47,8 @@ class ShortcutsManager {
         guard let data = UserDefaults.standard.data(forKey: type.rawValue) else { return nil }
         do {
             let shortcut = try NSKeyedUnarchiver.unarchivedObject(ofClass: Shortcut.self, from: data)
-            return UserShortcut(type: type, shortcut: shortcut)
+            // TODO: mouseButton should also be saved in save() and retrieved here
+            return UserShortcut(type: type, shortcut: shortcut, mouseButton: .none)
         } catch {
             print("Error unarchiving data: \(error.localizedDescription)")
             return nil

--- a/Swift Shift/src/shortchuts/ShortcutsManager.swift
+++ b/Swift Shift/src/shortchuts/ShortcutsManager.swift
@@ -9,6 +9,15 @@ enum MouseButton: String, CaseIterable {
     case none = "None"
     case left = "Left"
     case right = "Right"
+
+    static func parse(rawValue: String?) -> MouseButton {
+      guard let rawValue = rawValue else { return .none }
+      if let value = MouseButton(rawValue: rawValue) {
+        return value
+      } else {
+        return .none
+      }
+    }
 }
 
 struct UserShortcut {
@@ -36,6 +45,7 @@ class ShortcutsManager {
             if let shortcut = userShortcut.shortcut {
                 let data = try NSKeyedArchiver.archivedData(withRootObject: shortcut, requiringSecureCoding: false)
                 UserDefaults.standard.set(data, forKey: userShortcut.type.rawValue)
+                UserDefaults.standard.set(userShortcut.mouseButton.rawValue, forKey: "\(userShortcut.type.rawValue)_mouseButton")
             }
         } catch {
             print("Error: \(error)")
@@ -47,8 +57,8 @@ class ShortcutsManager {
         guard let data = UserDefaults.standard.data(forKey: type.rawValue) else { return nil }
         do {
             let shortcut = try NSKeyedUnarchiver.unarchivedObject(ofClass: Shortcut.self, from: data)
-            // TODO: mouseButton should also be saved in save() and retrieved here
-            return UserShortcut(type: type, shortcut: shortcut, mouseButton: .none)
+            let mouseButton = MouseButton.parse(rawValue: UserDefaults.standard.string(forKey: "\(type.rawValue)_mouseButton"))
+            return UserShortcut(type: type, shortcut: shortcut, mouseButton: mouseButton)
         } catch {
             print("Error unarchiving data: \(error.localizedDescription)")
             return nil


### PR DESCRIPTION
Continuing on the work done in #22 resolving #16

1. Store and Load mouse settings
2. Add CGEventSupervisor as a dependency, since it allows intercepting global mouse events synchronously with the ability to cancel (prevents context menu popping up when right-clicking, etc.)
3. Track mouse button on shortcut instead of tracking mouse move immediately
4. Track appropriate mouse move event for the given mouse button option

I tried to take a video but because the mouse clicks are intercepted, they don't show up in any recording software I try use.