### PR TITLE
Remove the redundant "Require mouse click"

### DIFF
--- a/Swift Shift/src/View/PreferencesView.swift
+++ b/Swift Shift/src/View/PreferencesView.swift
@@ -5,7 +5,6 @@ struct PreferencesView: View {
   @AppStorage(PreferenceKey.showMenuBarIcon.rawValue) var showMenuBarIcon = true
   @AppStorage(PreferenceKey.focusOnApp.rawValue) var focusOnApp = true
   @AppStorage(PreferenceKey.useQuadrants.rawValue) var useQuadrants = false
-  @AppStorage(PreferenceKey.requireMouseClick.rawValue) var requireMouseClick = false
   
   var body: some View {
     VStack(alignment: .leading) {
@@ -29,16 +28,6 @@ struct PreferencesView: View {
         Text("The resize action will happen from the edge/corner that's closer to your mouse")
           .fixedSize(horizontal: false, vertical: true)
       }
-      
-      Toggle(isOn: $requireMouseClick) {
-        Text("Require mouse click")
-        Text("Allows you to use the mouse buttons in your shortcuts")
-          .fixedSize(horizontal: false, vertical: true)
-      }.onChange(of: requireMouseClick, perform: { newValue in
-        if newValue == false {
-          ShortcutsManager.shared.removeClickActionsForAll()
-        }
-      })
     }
   }
 }

--- a/Swift Shift/src/View/ShortcutView.swift
+++ b/Swift Shift/src/View/ShortcutView.swift
@@ -69,7 +69,6 @@ struct ShortcutView: View {
           shortcut.shortcut = nil
         }
       }
-      if requireMouseClick {
         HStack {
           Image(systemName: "magicmouse.fill")
             .foregroundColor(.secondary)
@@ -101,7 +100,6 @@ struct ShortcutView: View {
           // this is needed when we update the mouse to .none from PreferencesView
           loadShortcutFromStorage()
         }
-      }
     }
   }
   


### PR DESCRIPTION
The mouse click option is redundant and confusing. Just having the choice between None/Right/Left is clearer, more flexible and overall simpler too.

Before:
<img width="366" alt="" src="https://github.com/user-attachments/assets/0ecddba2-cb35-41ff-9757-1639a0b3bdc9" />

After:
<img width="366" alt="" src="https://github.com/user-attachments/assets/8b924d08-39b1-42c5-9057-d17aeb1fe16f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Features Removed**
	- Removed mouse click requirement toggle from preferences
	- Eliminated mouse button selection options in shortcut configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->