### PR TITLE
feat: ignore custom apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ There are several ways:
 * Hide menubar icon
 * Focus on window
 * Smart resizing with quadrants
+* Ignore custom apps
 
 ### Quadrants
 

--- a/Swift Shift.xcodeproj/project.pbxproj
+++ b/Swift Shift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		17087D952DD254890006852C /* IgnoredAppsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17087D942DD254890006852C /* IgnoredAppsTabView.swift */; };
 		172E0BD52B32F36300D5CDA7 /* MouseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172E0BD42B32F36300D5CDA7 /* MouseTracker.swift */; };
 		173C0E832C123CF700654527 /* DrawCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173C0E822C123CF700654527 /* DrawCircle.swift */; };
 		174652CE2B33345200241CE6 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174652CD2B33345200241CE6 /* WindowManager.swift */; };
@@ -34,6 +35,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		17087D942DD254890006852C /* IgnoredAppsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoredAppsTabView.swift; sourceTree = "<group>"; };
 		172E0BD42B32F36300D5CDA7 /* MouseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseTracker.swift; sourceTree = "<group>"; };
 		173C0E822C123CF700654527 /* DrawCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawCircle.swift; sourceTree = "<group>"; };
 		174652CD2B33345200241CE6 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManager.swift; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 				E236331F2B4466F800C0E61F /* PreferencesView.swift */,
 				1798B11F2B4812D600E07964 /* SettingsView.swift */,
 				1798B1212B48131400E07964 /* InfoView.swift */,
+				17087D942DD254890006852C /* IgnoredAppsTabView.swift */,
 				E2CABBA42B447AEA00D66D43 /* UpdatesView.swift */,
 				177FB24B2B31FF1E00B11BA3 /* ShortcutView.swift */,
 				177FB2402B31F9B900B11BA3 /* PermissionsRequestView.swift */,
@@ -248,6 +251,7 @@
 				1781A5E42B31EE4A00F27910 /* AppView.swift in Sources */,
 				173C0E832C123CF700654527 /* DrawCircle.swift in Sources */,
 				E2CABBA52B447AEA00D66D43 /* UpdatesView.swift in Sources */,
+				17087D952DD254890006852C /* IgnoredAppsTabView.swift in Sources */,
 				177FB2532B321D0500B11BA3 /* ShortcutsManager.swift in Sources */,
 				E2E6F5EA2B3EF03C005B0D96 /* Constants.swift in Sources */,
 				E2CABBA82B44D69B00D66D43 /* UpdatesManager.swift in Sources */,

--- a/Swift Shift/src/Constants.swift
+++ b/Swift Shift/src/Constants.swift
@@ -1,4 +1,3 @@
-
 var IGNORE_APP_BUNDLE_ID = [
   "com.apple.notificationcenterui",
   "pl.maketheweb.cleanshotx",

--- a/Swift Shift/src/Manager/MouseTracker.swift
+++ b/Swift Shift/src/Manager/MouseTracker.swift
@@ -124,7 +124,7 @@ class MouseTracker {
   private func shouldIgnore(window: AXUIElement) -> Bool {
     guard let app = WindowManager.getNSApplication(from: window),
           let bundleIdentifier = app.bundleIdentifier,
-          IGNORE_APP_BUNDLE_ID.contains(bundleIdentifier) else {
+          PreferencesManager.isAppIgnored(bundleIdentifier) else {
       return false
     }
     print("Ignoring", bundleIdentifier)

--- a/Swift Shift/src/Manager/Preferences.swift
+++ b/Swift Shift/src/Manager/Preferences.swift
@@ -5,10 +5,54 @@ enum PreferenceKey: String {
     case showMenuBarIcon = "showMenuBarIcon"
     case useQuadrants = "useQuadrants"
     case requireMouseClick = "requireMouseClick"
+    case ignoredApps = "ignoredApps"
 }
 
 class PreferencesManager {
     static func loadBool(for key: PreferenceKey) -> Bool {
         return UserDefaults.standard.bool(forKey: key.rawValue)
+    }
+    
+    static func getIgnoredApps() -> [String] {
+        // Include default apps + user-added apps
+        if let savedApps = UserDefaults.standard.array(forKey: PreferenceKey.ignoredApps.rawValue) as? [String] {
+            return Array(Set(IGNORE_APP_BUNDLE_ID + savedApps)) // Ensure no duplicates
+        }
+        return IGNORE_APP_BUNDLE_ID
+    }
+    
+    static func getUserIgnoredApps() -> [String] {
+        // Return only user-added apps
+        if let savedApps = UserDefaults.standard.array(forKey: PreferenceKey.ignoredApps.rawValue) as? [String] {
+            return savedApps
+        }
+        return []
+    }
+    
+    static func setUserIgnoredApps(_ apps: [String]) {
+        UserDefaults.standard.set(apps, forKey: PreferenceKey.ignoredApps.rawValue)
+    }
+    
+    static func addIgnoredApp(_ bundleId: String) {
+        var currentList = getUserIgnoredApps()
+        
+        // Don't add apps that are already in default list
+        if !IGNORE_APP_BUNDLE_ID.contains(bundleId) && !currentList.contains(bundleId) {
+            currentList.append(bundleId)
+            setUserIgnoredApps(currentList)
+        }
+    }
+    
+    static func removeIgnoredApp(_ bundleId: String) {
+        // Only remove from user list if it's not in the default list
+        if !IGNORE_APP_BUNDLE_ID.contains(bundleId) {
+            var currentList = getUserIgnoredApps()
+            currentList.removeAll { $0 == bundleId }
+            setUserIgnoredApps(currentList)
+        }
+    }
+    
+    static func isAppIgnored(_ bundleId: String) -> Bool {
+        return getIgnoredApps().contains(bundleId)
     }
 }

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -85,8 +85,8 @@ class WindowManager {
           var value: AnyObject?
           
           if let app = getNSApplication(from: appAXUIElement) {
-            if (IGNORE_APP_BUNDLE_ID.contains(app.bundleIdentifier!)) {
-              print("ignoring", app.bundleIdentifier! as String)
+            if let bundleId = app.bundleIdentifier, PreferencesManager.isAppIgnored(bundleId) {
+              print("ignoring", bundleId)
               continue
             }
           }

--- a/Swift Shift/src/View/AppView.swift
+++ b/Swift Shift/src/View/AppView.swift
@@ -3,7 +3,7 @@ import ShortcutRecorder
 import Sparkle
 
 enum Tab {
-  case settings, info
+  case settings, ignoredApps, info
 }
 
 struct TabButton: View {
@@ -31,6 +31,7 @@ struct AppView: View {
       // Tab bar
       HStack {
         TabButton(tab: .settings, selectedTab: $selectedTab, iconName: "gear")
+        TabButton(tab: .ignoredApps, selectedTab: $selectedTab, iconName: "macwindow.on.rectangle")
         TabButton(tab: .info, selectedTab: $selectedTab, iconName: "info.circle")
       }
       
@@ -39,6 +40,8 @@ struct AppView: View {
         switch selectedTab {
         case .settings:
           SettingsView()
+        case .ignoredApps:
+          IgnoredAppsTabView()
         case .info:
           InfoView()
         }

--- a/Swift Shift/src/View/IgnoredAppsTabView.swift
+++ b/Swift Shift/src/View/IgnoredAppsTabView.swift
@@ -12,11 +12,10 @@ struct IgnoredAppsTabView: View {
             VStack(alignment: .leading) {
                 Text("Ignored Applications").font(.title2).bold()
                 Text("Applications in this list will be ignored when using Swift Shift shortcuts.")
+                    .fixedSize(horizontal: false, vertical: true)
                     .font(.caption)
                     .foregroundColor(.secondary)
-                    .padding(.bottom, 5)
             }.padding(.horizontal)
-            
             
             VStack(alignment: .leading, spacing: 10) {
                 VStack(alignment: .leading) {
@@ -34,6 +33,10 @@ struct IgnoredAppsTabView: View {
                             .foregroundColor(.secondary)
                             .padding()
                             .frame(maxWidth: .infinity, alignment: .center)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 5)
+                                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                            )
                     } else {
                         List {
                             ForEach(ignoredApps, id: \.self) { bundleId in
@@ -50,8 +53,9 @@ struct IgnoredAppsTabView: View {
                                 }.padding(.vertical, 5)
                             }
                             .listRowBackground(Color.clear)
+                            .listRowSeparatorTint(Color.gray.opacity(0.3))
                         }
-                        .frame(height: 200)
+                        .frame(height: 150)
                         .overlay(
                             RoundedRectangle(cornerRadius: 5)
                                 .stroke(Color.gray.opacity(0.3), lineWidth: 1)
@@ -61,10 +65,8 @@ struct IgnoredAppsTabView: View {
             }
             .padding(.horizontal)
             
-            Spacer()
-            
             VStack(alignment: .leading) {
-                Text("Note: Some system applications are already ignored by default.")
+                Text("Note: Some applications are already ignored by default.")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }

--- a/Swift Shift/src/View/IgnoredAppsTabView.swift
+++ b/Swift Shift/src/View/IgnoredAppsTabView.swift
@@ -70,8 +70,7 @@ struct IgnoredAppsTabView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
-            .padding(.horizontal)
-            .padding(.bottom)
+            .padding()
         }
         .onAppear {
             loadApps()

--- a/Swift Shift/src/View/IgnoredAppsTabView.swift
+++ b/Swift Shift/src/View/IgnoredAppsTabView.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+
+struct IgnoredAppsTabView: View {
+    @State private var ignoredApps: [String] = []
+    @State private var defaultIgnoredApps: [String] = []
+    @State private var appNames: [String: String] = [:]
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            VStack(alignment: .leading) {
+                Text("Ignored Applications").font(.title2).bold()
+                Text("Applications in this list will be ignored when using Swift Shift shortcuts.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.bottom, 5)
+            }.padding(.horizontal)
+            
+            
+            VStack(alignment: .leading, spacing: 10) {
+                VStack(alignment: .leading) {
+                    HStack {
+                        Button(action: {
+                            selectApp()
+                        }) {
+                            Label("Add", systemImage: "plus.circle")
+                        }
+                    }.padding(.bottom, 2)
+                    
+                    if ignoredApps.isEmpty {
+                        Text("No applications added")
+                            .italic()
+                            .foregroundColor(.secondary)
+                            .padding()
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    } else {
+                        List {
+                            ForEach(ignoredApps, id: \.self) { bundleId in
+                                HStack {
+                                    Text(appNames[bundleId] ?? bundleId)
+                                    Spacer()
+                                    Button(action: {
+                                        removeApp(bundleId)
+                                    }) {
+                                        Image(systemName: "trash")
+                                            .foregroundColor(.red)
+                                    }
+                                    .buttonStyle(BorderlessButtonStyle())
+                                }.padding(.vertical, 5)
+                            }
+                            .listRowBackground(Color.clear)
+                        }
+                        .frame(height: 200)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 5)
+                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal)
+            
+            Spacer()
+            
+            VStack(alignment: .leading) {
+                Text("Note: Some system applications are already ignored by default.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal)
+            .padding(.bottom)
+        }
+        .onAppear {
+            loadApps()
+        }
+    }
+    
+    private func loadApps() {
+        defaultIgnoredApps = IGNORE_APP_BUNDLE_ID
+        ignoredApps = PreferencesManager.getUserIgnoredApps()
+        
+        // Resolve bundle IDs to app names
+        for bundleId in (defaultIgnoredApps + ignoredApps) {
+            if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId),
+               let appBundle = Bundle(url: appURL),
+               let appName = appBundle.object(forInfoDictionaryKey: "CFBundleName") as? String {
+                appNames[bundleId] = appName
+            }
+        }
+    }
+    
+    private func selectApp() {
+        let openPanel = NSOpenPanel()
+        openPanel.canChooseFiles = true
+        openPanel.canChooseDirectories = false
+        openPanel.allowsMultipleSelection = false
+        openPanel.allowedContentTypes = [UTType.application]
+        openPanel.directoryURL = URL(fileURLWithPath: "/Applications")
+        
+        // Activate the app first to ensure its windows are in front
+        NSApp.activate(ignoringOtherApps: true)
+        
+        // Use runModal for sheet-style presentation that will come to the front
+        let response = openPanel.runModal()
+        
+        if response == .OK, let selectedURL = openPanel.url {
+            if let bundle = Bundle(url: selectedURL), 
+               let bundleIdentifier = bundle.bundleIdentifier {
+                let appName = bundle.object(forInfoDictionaryKey: "CFBundleName") as? String ?? bundleIdentifier
+                
+                // Don't add if it's already in the default list
+                if !defaultIgnoredApps.contains(bundleIdentifier) {
+                    // Add to ignored apps list
+                    PreferencesManager.addIgnoredApp(bundleIdentifier)
+                    appNames[bundleIdentifier] = appName
+                    ignoredApps = PreferencesManager.getUserIgnoredApps()
+                }
+            }
+        }
+    }
+    
+    private func removeApp(_ bundleId: String) {
+        PreferencesManager.removeIgnoredApp(bundleId)
+        ignoredApps = PreferencesManager.getUserIgnoredApps()
+    }
+}
+
+#Preview {
+    IgnoredAppsTabView()
+} 


### PR DESCRIPTION
fix #45 

https://github.com/user-attachments/assets/050284ac-060a-48cc-8ef4-d405b4a39435



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an "Ignored Apps" tab to manage applications excluded from Swift Shift shortcuts.
  - Users can add or remove custom ignored apps alongside system-default ignored apps.
- **Improvements**
  - Updated app exclusion logic to honor user-configured ignored applications dynamically.
- **Documentation**
  - Updated feature list to highlight the ability to ignore custom apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->