### PR TITLE
Make entire tab area clickable, not just the icon

### DIFF
--- a/Swift Shift/src/View/AppView.swift
+++ b/Swift Shift/src/View/AppView.swift
@@ -42,6 +42,7 @@ struct AppView: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 7)
             .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
             .background(
               Group {
                 if selectedTab == tab {


### PR DESCRIPTION
Adds `.contentShape(Rectangle())` so the full tab button area is clickable, matching the mousetrap implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab button click responsiveness by expanding the interactive hit area to the entire button surface for more reliable tapping and clicking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->