### PR TITLE
Use a separate dev bundle ID for Debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 		CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
 run-app:
-	open "./build/Debug/Swift Shift.app"
+	open "./build/Debug/Swift Shift Dev.app"
 
 run: build run-app
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,7 @@ make run
 
 ### Accessibility permissions running locally
 
-Make sure you don't have Swift Shift running already. If you have 2 versions of Swift Shift, only one will get
-Accessibility permissions. To fix it:
-
-* Quit all Swift Shift instances
-* Remove Swift Shift from the System Preferences > Security & Privacy > Accessibility
-* Run the app you want to test
-* Enable Accessibility permissions
+Local Debug builds use a separate app identity (`Swift Shift Dev` / `com.pablopunk.Swift-Shift.dev`), so they can coexist with the released app without reusing the same Accessibility permission entry.
 
 I'm open to PRs and requests. If you are looking for something to do, take a look at the issues marked as [`help wanted`](https://github.com/pablopunk/SwiftShift/issues?q=is:issue+is:open+label:%22help+wanted%22).
 

--- a/Swift Shift.xcodeproj/project.pbxproj
+++ b/Swift Shift.xcodeproj/project.pbxproj
@@ -45,7 +45,7 @@
 		177FB24B2B31FF1E00B11BA3 /* ShortcutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutView.swift; sourceTree = "<group>"; };
 		177FB2502B32160B00B11BA3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		177FB2522B321D0500B11BA3 /* ShortcutsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsManager.swift; sourceTree = "<group>"; };
-		1781A5DE2B31EE4900F27910 /* Swift Shift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Swift Shift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1781A5DE2B31EE4900F27910 /* Swift Shift Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Swift Shift Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1781A5E12B31EE4A00F27910 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		1781A5E32B31EE4A00F27910 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
 		1781A5E52B31EE4B00F27910 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -138,7 +138,7 @@
 		1781A5DF2B31EE4900F27910 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				1781A5DE2B31EE4900F27910 /* Swift Shift.app */,
+				1781A5DE2B31EE4900F27910 /* Swift Shift Dev.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -186,7 +186,7 @@
 				336441102C189812000A1C90 /* CGEventSupervisor */,
 			);
 			productName = "Swift Shift";
-			productReference = 1781A5DE2B31EE4900F27910 /* Swift Shift.app */;
+			productReference = 1781A5DE2B31EE4900F27910 /* Swift Shift Dev.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -406,7 +406,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Swift-Shift-Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "Swift Shift";
+				INFOPLIST_KEY_CFBundleDisplayName = "Swift Shift Dev";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -416,8 +416,8 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.pablopunk.Swift-Shift";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pablopunk.Swift-Shift.dev";
+				PRODUCT_NAME = "$(TARGET_NAME) Dev";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};


### PR DESCRIPTION
## Summary
- give Debug builds their own bundle identifier and app name (`Swift Shift Dev`)
- keep Release using the existing production bundle identifier
- update `make run` and the README to reflect the new Debug app identity

## Testing
- make build

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on running local builds to clarify they use a separate app identity, eliminating conflicts with the released version and removing outdated troubleshooting steps.

* **Chores**
  * Updated build configuration to create a distinct development app instance for local builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablopunk/SwiftShift/pull/137)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->