### PR TITLE
Fix Mission Control clicks with mouse shortcuts

### DIFF
--- a/Swift Shift/src/Manager/ShortcutsManager.swift
+++ b/Swift Shift/src/Manager/ShortcutsManager.swift
@@ -534,6 +534,10 @@ class ShortcutsManager {
       to: .cgEvents(downEvent),
       using: { [weak self] event in
         guard let self = self, self.activeShortcuts[userShortcut.type] == true else { return }
+        guard self.isShortcutStillPressed(userShortcut) else {
+          self.stopTracking(userShortcut, action)
+          return
+        }
         event.cancel()
         MouseTracker.shared.startTracking(for: action, button: userShortcut.mouseButton)
       })
@@ -543,6 +547,10 @@ class ShortcutsManager {
       to: .cgEvents(upEvent),
       using: { [weak self] event in
         guard let self = self, self.activeShortcuts[userShortcut.type] == true else { return }
+        guard self.isShortcutStillPressed(userShortcut) else {
+          self.stopTracking(userShortcut, action)
+          return
+        }
         event.cancel()
         MouseTracker.shared.stopTracking(for: action)
       })
@@ -555,6 +563,11 @@ class ShortcutsManager {
     MouseTracker.shared.stopTracking(for: action)
     cleanupMouseSubscriptions(action: action)
     activeShortcuts[userShortcut.type] = false
+  }
+
+  private func isShortcutStillPressed(_ userShortcut: UserShortcut) -> Bool {
+    guard let keyboardShortcut = userShortcut.keyboardShortcut else { return false }
+    return NSEvent.modifierFlags.swiftShiftShortcutFlags == keyboardShortcut.modifierFlags
   }
 
   private func cleanupMouseSubscriptions(action: MouseAction) {


### PR DESCRIPTION
## Summary
- Fixes #77
- Re-check the current physical modifier state before canceling mouse clicks for require-mouse-click shortcuts
- Clean up stale tracking when macOS/Mission Control swallows the shortcut release event

## Testing
- `xcodebuild -project "Swift Shift.xcodeproj" -scheme "Swift Shift" -configuration Debug build CODE_SIGNING_ALLOWED=NO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut behavior for mouse tracking actions. The system now verifies that modifier keys remain held throughout tracking. If modifiers are released during a mouse action, tracking immediately stops, preventing unintended behavior and enhancing overall shortcut reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablopunk/SwiftShift/pull/145)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->