### PR TITLE
Defensively clean up mouse click subscriptions

### DIFF
--- a/Swift Shift/src/Manager/ShortcutsManager.swift
+++ b/Swift Shift/src/Manager/ShortcutsManager.swift
@@ -200,8 +200,13 @@ class ShortcutsManager {
   }
 
   private func handleSpaceChange() {
-    for type in ShortcutType.allCases {
-      if activeShortcuts[type] == true {
+    for type in ShortcutType.allCases where activeShortcuts[type] == true {
+      let action: MouseAction = type == .move ? .move : .resize
+      if let loaded = load(for: type) {
+        stopTracking(loaded, action)
+      } else {
+        MouseTracker.shared.stopTracking(for: action)
+        cleanupMouseSubscriptions(action: action)
         activeShortcuts[type] = false
       }
     }
@@ -528,6 +533,10 @@ class ShortcutsManager {
     let upEvent: CGEventType = userShortcut.mouseButton == .left ? .leftMouseUp : .rightMouseUp
     let downKey = "\(action.rawValue)_mouseDown"
     let upKey = "\(action.rawValue)_mouseUp"
+
+    // Be defensive: shortcut events can arrive repeatedly or cleanup can be skipped
+    // by system state changes. Ensure we never accumulate duplicate event taps.
+    cleanupMouseSubscriptions(action: action)
 
     CGEventSupervisor.shared.subscribe(
       as: downKey,


### PR DESCRIPTION
## Summary
- cancel existing mouse click subscriptions before re-subscribing
- route Space changes through normal tracking cleanup
- reduce risk of accumulating event taps when “require mouse click” is enabled

Fixes #68
Fixes #47

## Test
- xcodebuild -project "Swift Shift.xcodeproj" -scheme "Swift Shift" -configuration Debug build CODE_SIGNING_ALLOWED=NO
- manually tested require mouse click behavior locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where mouse tracking subscriptions could accumulate unnecessarily, improving application stability and resource usage during space changes.
  * Enhanced handling of shortcut loading failures to ensure tracking processes are properly cleaned up.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablopunk/SwiftShift/pull/149)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->