### PR TITLE
Add window edge snapping resistance

### DIFF
--- a/Swift Shift/src/Manager/MouseTracker.swift
+++ b/Swift Shift/src/Manager/MouseTracker.swift
@@ -7,10 +7,12 @@ class MouseTracker {
     private var mouseEventMonitor: Any?, initialMouseLocation, initialWindowLocation: NSPoint?
     private var trackedWindow: AXUIElement?, trackedWindowIsFocused = false, shouldFocusWindow = false
     private var currentAction: MouseAction = .none, trackingTimer: Timer?
-    private let trackingTimeout: TimeInterval = 4, minimumUpdateInterval: TimeInterval = 1.0 / 120.0
+    private let trackingTimeout: TimeInterval = 10, minimumUpdateInterval: TimeInterval = 1.0 / 120.0
     private var shouldUseQuadrants = false, quadrant: Quadrant?, windowSize: CGSize?, isTracking = false
     private var spaceChangeObserver: Any?, pendingMouseLocation: NSPoint?, lastUpdateTime: TimeInterval = 0
     private var lastAppliedOrigin: NSPoint?, lastAppliedSize: CGSize?
+    private var snapRects: [CGRect] = []
+    private let snapDistance: CGFloat = 10
     private let trackingQueue = DispatchQueue(label: "com.swiftshift.mousetracker")
     private init() { registerForSpaceChangeNotifications() }
     deinit { unregisterForSpaceChangeNotifications() }
@@ -50,6 +52,7 @@ class MouseTracker {
         trackedWindowIsFocused = false; currentAction = action; initialMouseLocation = NSEvent.mouseLocation
         trackedWindow = currentWindow; initialWindowLocation = WindowManager.getPosition(window: currentWindow)
         windowSize = WindowManager.getSize(window: currentWindow); pendingMouseLocation = nil; lastUpdateTime = 0
+        snapRects = WindowManager.getVisibleWindowRects(excluding: currentWindow)
         lastAppliedOrigin = initialWindowLocation; lastAppliedSize = windowSize
         if action == .resize && shouldUseQuadrants, let m = initialMouseLocation, let w = initialWindowLocation, let s = windowSize {
             quadrant = determineQuadrant(mouseLocation: m, windowSize: s, windowLocation: w)
@@ -103,7 +106,8 @@ class MouseTracker {
     private func moveWindowBasedOnMouseLocation(_ loc: NSPoint) {
         guard let im = initialMouseLocation, let iw = initialWindowLocation, let w = trackedWindow else { return }
         let dx = loc.x - im.x, dy = loc.y - im.y
-        let newO = NSPoint(x: iw.x + dx, y: iw.y - dy)
+        var newO = NSPoint(x: iw.x + dx, y: iw.y - dy)
+        if let size = windowSize { newO = snappedOrigin(forMoving: CGRect(origin: newO, size: size)) }
         if !pointsApproximatelyEqual(newO, lastAppliedOrigin) { lastAppliedOrigin = newO; WindowManager.move(window: w, to: newO) }
     }
     private func resizeWindowBasedOnMouseLocation(_ loc: NSPoint) {
@@ -125,15 +129,70 @@ class MouseTracker {
         } else {
             nw = s.width + (loc.x - im.x); nh = s.height - (loc.y - im.y)
         }
-        nw = max(nw, 1); nh = max(nh, 1); let ns = CGSize(width: nw, height: nh)
+        nw = max(nw, 1); nh = max(nh, 1)
+        let snapped = snappedResize(origin: no, size: CGSize(width: nw, height: nh))
+        no = snapped.origin; nw = snapped.size.width; nh = snapped.size.height
+        let ns = CGSize(width: nw, height: nh)
         let moveO = !pointsApproximatelyEqual(no, lastAppliedOrigin)
         if moveO || !sizesApproximatelyEqual(ns, lastAppliedSize) {
             lastAppliedOrigin = no; lastAppliedSize = ns; WindowManager.resize(window: w, to: ns, from: no, shouldMoveOrigin: moveO)
         }
     }
+    private func snappedOrigin(forMoving rect: CGRect) -> NSPoint {
+        let dx = closestSnapDelta(
+            from: [rect.minX, rect.maxX],
+            candidates: snapRects.filter { rangesOverlap(rect.minY...rect.maxY, $0.minY...$0.maxY) }.flatMap { [$0.minX, $0.maxX] }
+        ) ?? 0
+        let dy = closestSnapDelta(
+            from: [rect.minY, rect.maxY],
+            candidates: snapRects.filter { rangesOverlap(rect.minX...rect.maxX, $0.minX...$0.maxX) }.flatMap { [$0.minY, $0.maxY] }
+        ) ?? 0
+        return NSPoint(x: rect.origin.x + dx, y: rect.origin.y + dy)
+    }
+    private func snappedResize(origin: NSPoint, size: CGSize) -> (origin: NSPoint, size: CGSize) {
+        var left = origin.x, right = origin.x + size.width, top = origin.y, bottom = origin.y + size.height
+        let edges = activeResizeEdges()
+        let horizontalCandidates = snapRects.filter { rangesOverlap(top...bottom, $0.minY...$0.maxY) }.flatMap { [$0.minX, $0.maxX] }
+        let verticalCandidates = snapRects.filter { rangesOverlap(left...right, $0.minX...$0.maxX) }.flatMap { [$0.minY, $0.maxY] }
+        if edges.left, let dx = closestSnapDelta(from: [left], candidates: horizontalCandidates) { left += dx }
+        if edges.right, let dx = closestSnapDelta(from: [right], candidates: horizontalCandidates) { right += dx }
+        if edges.top, let dy = closestSnapDelta(from: [top], candidates: verticalCandidates) { top += dy }
+        if edges.bottom, let dy = closestSnapDelta(from: [bottom], candidates: verticalCandidates) { bottom += dy }
+        let snappedOrigin = NSPoint(x: min(left, right - 1), y: min(top, bottom - 1))
+        let snappedSize = CGSize(width: max(right - left, 1), height: max(bottom - top, 1))
+        return (snappedOrigin, snappedSize)
+    }
+    private func activeResizeEdges() -> (left: Bool, right: Bool, top: Bool, bottom: Bool) {
+        guard shouldUseQuadrants, let q = quadrant else { return (false, true, false, true) }
+        switch q {
+            case .topLeft: return (true, false, true, false)
+            case .top: return (false, false, true, false)
+            case .topRight: return (false, true, true, false)
+            case .left: return (true, false, false, false)
+            case .center: return (true, true, true, true)
+            case .right: return (false, true, false, false)
+            case .bottomLeft: return (true, false, false, true)
+            case .bottom: return (false, false, false, true)
+            case .bottomRight: return (false, true, false, true)
+        }
+    }
+    private func closestSnapDelta(from movingEdges: [CGFloat], candidates targetEdges: [CGFloat]) -> CGFloat? {
+        var closest: CGFloat?
+        for moving in movingEdges {
+            for target in targetEdges {
+                let delta = target - moving
+                guard abs(delta) <= snapDistance else { continue }
+                if closest == nil || abs(delta) < abs(closest!) { closest = delta }
+            }
+        }
+        return closest
+    }
+    private func rangesOverlap(_ a: ClosedRange<CGFloat>, _ b: ClosedRange<CGFloat>) -> Bool {
+        return a.lowerBound <= b.upperBound && b.lowerBound <= a.upperBound
+    }
     private func invalidateTrackingTimer() { trackingTimer?.invalidate(); trackingTimer = nil }
     private func removeMouseEventMonitor() { if let m = mouseEventMonitor { NSEvent.removeMonitor(m); mouseEventMonitor = nil } }
-    private func resetTrackingVariables() { pendingMouseLocation = nil; lastUpdateTime = 0; lastAppliedOrigin = nil; lastAppliedSize = nil; trackedWindow = nil; initialMouseLocation = nil; initialWindowLocation = nil; currentAction = .none; quadrant = nil; windowSize = nil }
+    private func resetTrackingVariables() { pendingMouseLocation = nil; lastUpdateTime = 0; lastAppliedOrigin = nil; lastAppliedSize = nil; snapRects = []; trackedWindow = nil; initialMouseLocation = nil; initialWindowLocation = nil; currentAction = .none; quadrant = nil; windowSize = nil }
     func pauseTracking() { isTracking = false }
     func resumeTracking() { if currentAction != .none && trackedWindow != nil { isTracking = true } }
     private func checkForKeyPresses() -> Bool {

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -33,7 +33,7 @@ class WindowManager {
                   let bounds = info[kCGWindowBounds as String] as? [String: CGFloat],
                   let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary),
                   rect.width > 1, rect.height > 1 else { return nil }
-            if let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier, PreferencesManager.isAppIgnored(bundleId) { return nil }
+            guard let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier, !PreferencesManager.isAppIgnored(bundleId) else { return nil }
             if let excludedRect = excludedRect, rect.equalTo(excludedRect) { return nil }
             return rect
         }

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -21,23 +21,22 @@ class WindowManager {
         var s: CGSize = .zero; AXValueGetValue(r as! AXValue, .cgSize, &s); return NSSize(width: s.width, height: s.height)
     }
     static func getVisibleWindowRects(excluding excludedWindow: AXUIElement? = nil) -> [CGRect] {
+        let excludedRect: CGRect? = {
+            guard let window = excludedWindow, let position = getPosition(window: window), let size = getSize(window: window) else { return nil }
+            return CGRect(origin: position, size: size)
+        }()
         let windowInfo = CGWindowListCopyWindowInfo([.excludeDesktopElements, .optionOnScreenOnly], kCGNullWindowID) as? [[String: AnyObject]] ?? []
-        var seenPIDs = Set<pid_t>()
-        var rects: [CGRect] = []
-        for info in windowInfo {
-            guard (info[kCGWindowLayer as String] as? Int ?? 0) == 0, let pid = info[kCGWindowOwnerPID as String] as? pid_t, pid != NSRunningApplication.current.processIdentifier, !seenPIDs.contains(pid) else { continue }
-            seenPIDs.insert(pid)
-            let app = AXUIElementCreateApplication(pid)
-            if let nsApp = getNSApplication(from: app), let bid = nsApp.bundleIdentifier, PreferencesManager.isAppIgnored(bid) { continue }
-            var value: AnyObject?
-            guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &value) == .success, let windows = value as? [AXUIElement] else { continue }
-            for window in windows {
-                if let excludedWindow = excludedWindow, CFEqual(window, excludedWindow) { continue }
-                guard let position = getPosition(window: window), let size = getSize(window: window), size.width > 1, size.height > 1 else { continue }
-                rects.append(CGRect(origin: position, size: size))
-            }
+        return windowInfo.compactMap { info in
+            guard (info[kCGWindowLayer as String] as? Int ?? 0) == 0,
+                  let pid = info[kCGWindowOwnerPID as String] as? pid_t,
+                  pid != NSRunningApplication.current.processIdentifier,
+                  let bounds = info[kCGWindowBounds as String] as? [String: CGFloat],
+                  let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary),
+                  rect.width > 1, rect.height > 1 else { return nil }
+            if let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier, PreferencesManager.isAppIgnored(bundleId) { return nil }
+            if let excludedRect = excludedRect, rect.intersection(excludedRect).equalTo(excludedRect) { return nil }
+            return rect
         }
-        return rects
     }
     static func getCurrentWindow() -> AXUIElement? {
         guard let ev = CGEvent(source: nil) else { return nil }

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -20,6 +20,25 @@ class WindowManager {
         var r: CFTypeRef?; guard AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &r) == .success else { return nil }
         var s: CGSize = .zero; AXValueGetValue(r as! AXValue, .cgSize, &s); return NSSize(width: s.width, height: s.height)
     }
+    static func getVisibleWindowRects(excluding excludedWindow: AXUIElement? = nil) -> [CGRect] {
+        let windowInfo = CGWindowListCopyWindowInfo([.excludeDesktopElements, .optionOnScreenOnly], kCGNullWindowID) as? [[String: AnyObject]] ?? []
+        var seenPIDs = Set<pid_t>()
+        var rects: [CGRect] = []
+        for info in windowInfo {
+            guard (info[kCGWindowLayer as String] as? Int ?? 0) == 0, let pid = info[kCGWindowOwnerPID as String] as? pid_t, pid != NSRunningApplication.current.processIdentifier, !seenPIDs.contains(pid) else { continue }
+            seenPIDs.insert(pid)
+            let app = AXUIElementCreateApplication(pid)
+            if let nsApp = getNSApplication(from: app), let bid = nsApp.bundleIdentifier, PreferencesManager.isAppIgnored(bid) { continue }
+            var value: AnyObject?
+            guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &value) == .success, let windows = value as? [AXUIElement] else { continue }
+            for window in windows {
+                if let excludedWindow = excludedWindow, CFEqual(window, excludedWindow) { continue }
+                guard let position = getPosition(window: window), let size = getSize(window: window), size.width > 1, size.height > 1 else { continue }
+                rects.append(CGRect(origin: position, size: size))
+            }
+        }
+        return rects
+    }
     static func getCurrentWindow() -> AXUIElement? {
         guard let ev = CGEvent(source: nil) else { return nil }
         let sys = AXUIElementCreateSystemWide(); var el: AXUIElement?

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -34,7 +34,7 @@ class WindowManager {
                   let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary),
                   rect.width > 1, rect.height > 1 else { return nil }
             if let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier, PreferencesManager.isAppIgnored(bundleId) { return nil }
-            if let excludedRect = excludedRect, rect.contains(excludedRect) { return nil }
+            if let excludedRect = excludedRect, rect.equalTo(excludedRect) { return nil }
             return rect
         }
     }

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -34,7 +34,7 @@ class WindowManager {
                   let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary),
                   rect.width > 1, rect.height > 1 else { return nil }
             if let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier, PreferencesManager.isAppIgnored(bundleId) { return nil }
-            if let excludedRect = excludedRect, rect.intersection(excludedRect).equalTo(excludedRect) { return nil }
+            if let excludedRect = excludedRect, rect.equalTo(excludedRect) { return nil }
             return rect
         }
     }

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -34,7 +34,7 @@ class WindowManager {
                   let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary),
                   rect.width > 1, rect.height > 1 else { return nil }
             if let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier, PreferencesManager.isAppIgnored(bundleId) { return nil }
-            if let excludedRect = excludedRect, rect.equalTo(excludedRect) { return nil }
+            if let excludedRect = excludedRect, rect.contains(excludedRect) { return nil }
             return rect
         }
     }


### PR DESCRIPTION
## Summary
- Add subtle 10px snapping resistance when moving/resizing near neighboring window edges
- Cache visible neighboring window rects at tracking start for performance
- Only snap against windows overlapping on the perpendicular axis


https://github.com/user-attachments/assets/fa7cdd16-6598-48c6-b179-c398b5194d12



Fixes #44

## Test plan
- Built successfully with `xcodebuild -project "Swift Shift.xcodeproj" -scheme "Swift Shift" -configuration Debug build`
- Manually tested window snapping behavior while moving/resizing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows snap to nearby visible windows when moving or resizing for cleaner alignment.
  * Snapping uses smarter edge-based matching and filters out the active window itself from snap candidates.

* **Bug Fixes / Improvements**
  * More responsive tracking with a longer timeout.
  * Prevents zero-size resize results and avoids redundant move/resize updates for greater stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablopunk/SwiftShift/pull/150)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->