### PR TITLE
Expose default ignored apps in settings

### DIFF
--- a/Swift Shift/src/Constants.swift
+++ b/Swift Shift/src/Constants.swift
@@ -1,8 +1,13 @@
-let IGNORE_APP_BUNDLE_ID = [
-  "com.apple.notificationcenterui",
+let SYSTEM_IGNORED_APP_BUNDLE_ID = [
+  "com.apple.notificationcenterui"
+]
+
+let DEFAULT_IGNORED_APP_BUNDLE_ID = [
   "pl.maketheweb.cleanshotx",
   "pl.maketheweb.cleanshotx-setapp",
   "com.pointum.hazeover",
   "com.pointum.hazeover-setapp"
 ]
+
+let IGNORE_APP_BUNDLE_ID = SYSTEM_IGNORED_APP_BUNDLE_ID + DEFAULT_IGNORED_APP_BUNDLE_ID
 let MAIN_WINDOW_WIDTH = 320.0

--- a/Swift Shift/src/Manager/Preferences.swift
+++ b/Swift Shift/src/Manager/Preferences.swift
@@ -24,20 +24,17 @@ class PreferencesManager {
         if let cached = cachedIgnoredApps {
             return Array(cached)
         }
-        var apps = Set(IGNORE_APP_BUNDLE_ID)
-        if let savedApps = UserDefaults.standard.array(forKey: PreferenceKey.ignoredApps.rawValue) as? [String] {
-            apps.formUnion(savedApps)
-        }
+        var apps = Set(SYSTEM_IGNORED_APP_BUNDLE_ID)
+        apps.formUnion(getUserIgnoredApps())
         cachedIgnoredApps = apps
         return Array(apps)
     }
     
     static func getUserIgnoredApps() -> [String] {
-        // Return only user-added apps
         if let savedApps = UserDefaults.standard.array(forKey: PreferenceKey.ignoredApps.rawValue) as? [String] {
             return savedApps
         }
-        return []
+        return DEFAULT_IGNORED_APP_BUNDLE_ID
     }
     
     static func setUserIgnoredApps(_ apps: [String]) {
@@ -46,22 +43,20 @@ class PreferencesManager {
     }
     
     static func addIgnoredApp(_ bundleId: String) {
+        guard !SYSTEM_IGNORED_APP_BUNDLE_ID.contains(bundleId) else { return }
         var currentList = getUserIgnoredApps()
         
-        // Don't add apps that are already in default list
-        if !IGNORE_APP_BUNDLE_ID.contains(bundleId) && !currentList.contains(bundleId) {
+        if !currentList.contains(bundleId) {
             currentList.append(bundleId)
             setUserIgnoredApps(currentList)
         }
     }
     
     static func removeIgnoredApp(_ bundleId: String) {
-        // Only remove from user list if it's not in the default list
-        if !IGNORE_APP_BUNDLE_ID.contains(bundleId) {
-            var currentList = getUserIgnoredApps()
-            currentList.removeAll { $0 == bundleId }
-            setUserIgnoredApps(currentList)
-        }
+        guard !SYSTEM_IGNORED_APP_BUNDLE_ID.contains(bundleId) else { return }
+        var currentList = getUserIgnoredApps()
+        currentList.removeAll { $0 == bundleId }
+        setUserIgnoredApps(currentList)
     }
     
     static func isAppIgnored(_ bundleId: String) -> Bool {

--- a/Swift Shift/src/View/IgnoredAppsTabView.swift
+++ b/Swift Shift/src/View/IgnoredAppsTabView.swift
@@ -4,7 +4,6 @@ import UniformTypeIdentifiers
 
 struct IgnoredAppsTabView: View {
   @State private var ignoredApps: [String] = []
-  @State private var defaultIgnoredApps: [String] = []
   @State private var appNames: [String: String] = [:]
 
   var body: some View {
@@ -70,7 +69,7 @@ struct IgnoredAppsTabView: View {
         }
       }
 
-      Text("Some system apps are ignored by default.")
+      Text("System apps like Notification Center are always ignored.")
         .font(.system(size: 10))
         .foregroundStyle(.quaternary)
     }
@@ -79,9 +78,8 @@ struct IgnoredAppsTabView: View {
   }
 
   private func loadApps() {
-    defaultIgnoredApps = IGNORE_APP_BUNDLE_ID
     ignoredApps = PreferencesManager.getUserIgnoredApps()
-    for bundleId in (defaultIgnoredApps + ignoredApps) {
+    for bundleId in ignoredApps {
       if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId),
          let appBundle = Bundle(url: appURL),
          let appName = appBundle.object(forInfoDictionaryKey: "CFBundleName") as? String {
@@ -105,11 +103,9 @@ struct IgnoredAppsTabView: View {
       if let bundle = Bundle(url: selectedURL),
          let bundleIdentifier = bundle.bundleIdentifier {
         let appName = bundle.object(forInfoDictionaryKey: "CFBundleName") as? String ?? bundleIdentifier
-        if !defaultIgnoredApps.contains(bundleIdentifier) {
-          PreferencesManager.addIgnoredApp(bundleIdentifier)
-          appNames[bundleIdentifier] = appName
-          ignoredApps = PreferencesManager.getUserIgnoredApps()
-        }
+        PreferencesManager.addIgnoredApp(bundleIdentifier)
+        appNames[bundleIdentifier] = appName
+        ignoredApps = PreferencesManager.getUserIgnoredApps()
       }
     }
   }


### PR DESCRIPTION
## Summary
- Split always-hidden system ignored apps from user-visible default ignored apps
- Show default ignored apps like CleanShot/HazeOver in the Ignored Apps tab
- Allow users to remove/re-add those default ignored apps while keeping system apps always ignored

Fixes #104

## Test
- xcodebuild -project 'Swift Shift.xcodeproj' -scheme 'Swift Shift' -configuration Debug -quiet build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the app ignore list to distinguish between system-protected apps and user-ignored apps.
  * System apps (e.g., Notification Center) are now permanently protected and cannot be modified by users.
  * Updated UI messaging to clarify that certain system apps are always ignored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablopunk/SwiftShift/pull/152)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->