### PR TITLE
Fix focus on target window

### DIFF
--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -78,13 +78,15 @@ class WindowManager {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
         let trueValue = kCFBooleanTrue!
 
-        app.activate(options: [.activateIgnoringOtherApps])
-        AXUIElementSetAttributeValue(axApp, kAXFrontmostAttribute as CFString, trueValue)
         AXUIElementPerformAction(window, kAXRaiseAction as CFString)
         AXUIElementSetAttributeValue(axApp, kAXMainWindowAttribute as CFString, window)
         AXUIElementSetAttributeValue(axApp, kAXFocusedWindowAttribute as CFString, window)
         AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, trueValue)
         AXUIElementSetAttributeValue(window, kAXFocusedAttribute as CFString, trueValue)
+
+        AXUIElementSetAttributeValue(axApp, kAXFrontmostAttribute as CFString, trueValue)
+        // TODO: evaluate whether this works on sandboxed/Electron apps that ignore AX attributes.
+        app.activate(options: [.activateIgnoringOtherApps])
     }
     static func getNSApplication(from element: AXUIElement) -> NSRunningApplication? {
         var pid: pid_t = 0; AXUIElementGetPid(element, &pid); return NSRunningApplication(processIdentifier: pid)

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -73,7 +73,19 @@ class WindowManager {
         if let parent = p { return getWindow(from: parent as! AXUIElement) }
         return nil
     }
-    static func focus(window: AXUIElement) { AXUIElementPerformAction(window, kAXRaiseAction as CFString); getNSApplication(from: window)?.activate() }
+    static func focus(window: AXUIElement) {
+        guard let app = getNSApplication(from: window) else { return }
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        let trueValue = kCFBooleanTrue!
+
+        app.activate(options: [.activateIgnoringOtherApps])
+        AXUIElementSetAttributeValue(axApp, kAXFrontmostAttribute as CFString, trueValue)
+        AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+        AXUIElementSetAttributeValue(axApp, kAXMainWindowAttribute as CFString, window)
+        AXUIElementSetAttributeValue(axApp, kAXFocusedWindowAttribute as CFString, window)
+        AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, trueValue)
+        AXUIElementSetAttributeValue(window, kAXFocusedAttribute as CFString, trueValue)
+    }
     static func getNSApplication(from element: AXUIElement) -> NSRunningApplication? {
         var pid: pid_t = 0; AXUIElementGetPid(element, &pid); return NSRunningApplication(processIdentifier: pid)
     }
@@ -89,4 +101,3 @@ class WindowManager {
         return WindowBounds(topLeft: fixed, topRight: NSPoint(x: fixed.x + windowSize.width, y: fixed.y), bottomLeft: NSPoint(x: fixed.x, y: fixed.y - windowSize.height), bottomRight: NSPoint(x: fixed.x + windowSize.width, y: fixed.y - windowSize.height))
     }
 }
-


### PR DESCRIPTION
## Summary

- Make focus-on-window explicitly activate the owning app and mark it frontmost through Accessibility.
- Set the target AX window as the app main/focused window and mark the window itself main/focused after raising it.

## Root Cause

The previous helper only raised the AX window and called app activation. Raising can change z-order without making the target window the app focused/main window, so the Focus on window preference was unreliable.

## Validation

- xcodebuild -scheme "Swift Shift" build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window focusing and activation so selected windows reliably come to the foreground and retain correct main/frontmost/focused state across apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->