### PR TITLE
fix: recover CGEventTap after system events — fixes #167 system-wide input degradation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 www/node_modules/
 www/dist/
 www/.astro/
+Swift Shift/packages/CGEventSupervisor/.build/

--- a/FIXES.md
+++ b/FIXES.md
@@ -1,0 +1,62 @@
+# Fixes for Issue #167 — System-wide input degradation
+
+## Problem
+SwiftShift's mouse-click shortcuts (Command+click for Move, Command+right-click for Resize) use a CGEventTap to intercept mouse events. macOS silently disables event taps on sleep/wake, display changes, session lock, and slow callbacks — but SwiftShift had no recovery mechanism. A dead tap causes system-wide input lag because CGEventTaps are synchronous (WindowServer pauses all input until the callback returns).
+
+## Fixes applied
+
+### 1. CGEventSupervisor: Proper teardown (run loop source leak)
+**Files:** `CGEventSupervisor.swift`, `CGEventSupervisor+Setup.swift`
+
+- Added `eventTapRunLoopSource` stored property to track the run loop source
+- `teardown()` now removes the source from the run loop and invalidates the CFMachPort, not just disables the tap
+
+### 2. CGEventSupervisor: Handle disabled-tap events
+**File:** `CGEventSupervisor+Callback.swift`
+
+- The callback now checks for `.tapDisabledByTimeout` and `.tapDisabledByUserInput`
+- When detected, re-enables the tap via `CGEvent.tapEnable(tap:enable: true)`
+- Prevents silent tap death from slow callbacks
+
+### 3. ShortcutsManager: System event recovery
+**File:** `Swift Shift/src/Manager/ShortcutsManager.swift`
+
+Added observers for three system events that kill taps:
+- `NSWorkspace.didWakeNotification` — sleep/wake
+- `NSWorkspace.sessionDidBecomeActiveNotification` — screen lock/unlock, fast user switch
+- `NSApplication.didChangeScreenParametersNotification` — display connect/disconnect, resolution change
+
+`rebuildAllInputHooks()` now:
+1. Stops any active tracking and clears `activeShortcuts` state
+2. Tears down the current tap via `CGEventSupervisor.shared.cancelAll()`
+3. Rebuilds keyboard monitors via `updateGlobalShortcuts()`
+4. Force-rebuilds mouse chord subscriptions via `MouseChordActionManager.shared.forceRebuild()`
+
+### 4. MouseChordActionManager: forceRebuild()
+**File:** `Swift Shift/src/Manager/ShortcutsManager.swift`
+
+Added `forceRebuild()` which properly resets the internal `isSubscribed` flag before
+re-subscribing. This fixes a state corruption issue where `cancelAll()` could leave
+the `isSubscribed` flag true, causing `subscribeIfNeeded()` to return early without
+actually re-creating the CGEventSupervisor subscriber.
+
+`ShortcutsManager.rebuildAllInputHooks()` (not `forceRebuild()`) clears
+`activeShortcuts` and stops any in-progress tracking before rebuild,
+preventing stale modifier-key state from blocking future shortcut activations.
+
+### 5. MouseChordActionManager: Periodic tap health check
+**File:** `Swift Shift/src/Manager/ShortcutsManager.swift`
+
+Added a 60-second repeating timer that calls `forceRebuild()` when subscribed.
+This catches tap death from Secure Input (password prompts, sudo) and any other
+no-notification tap-killing scenarios by fully tearing down and rebuilding the
+subscription.
+
+### 6. CGEventSupervisor vendored into project
+**Files:** `Swift Shift/packages/CGEventSupervisor/`
+
+The CGEventSupervisor dependency (previously `stephancasas/CGEventSupervisor`)
+is now a local package. This allows us to ship the teardown and callback fixes
+without waiting for upstream. The package is unchanged except for the fixes
+documented in items 1 and 2 above.
+The reporter uses Command+click for Move and Command+right-click for Resize. Each shortcut press creates CGEventSupervisor subscriptions which create a CGEventTap. The tap dies silently on system events, and without recovery the tap stays dead — causing the system-wide input delay described in the bug. Restarting the app works because it creates a fresh tap.

--- a/Swift Shift.xcodeproj/project.pbxproj
+++ b/Swift Shift.xcodeproj/project.pbxproj
@@ -220,7 +220,7 @@
 				177FB2462B31FE7F00B11BA3 /* XCRemoteSwiftPackageReference "ShortcutRecorder" */,
 				17F33F282B37026400F85E01 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
 				E23633212B44749C00C0E61F /* XCRemoteSwiftPackageReference "Sparkle" */,
-				3364410F2C189812000A1C90 /* XCRemoteSwiftPackageReference "CGEventSupervisor" */,
+				3364410F2C189812000A1C90 /* XCLocalSwiftPackageReference "CGEventSupervisor" */,
 			);
 			productRefGroup = 1781A5DF2B31EE4900F27910 /* Products */;
 			projectDirPath = "";
@@ -501,13 +501,9 @@
 				kind = branch;
 			};
 		};
-		3364410F2C189812000A1C90 /* XCRemoteSwiftPackageReference "CGEventSupervisor" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/stephancasas/CGEventSupervisor";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
+		3364410F2C189812000A1C90 /* XCLocalSwiftPackageReference "CGEventSupervisor" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "Swift Shift/packages/CGEventSupervisor";
 		};
 		E23633212B44749C00C0E61F /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -522,7 +518,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		336441102C189812000A1C90 /* CGEventSupervisor */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3364410F2C189812000A1C90 /* XCRemoteSwiftPackageReference "CGEventSupervisor" */;
+			package = 3364410F2C189812000A1C90 /* XCLocalSwiftPackageReference "CGEventSupervisor" */;
 			productName = CGEventSupervisor;
 		};
 		338FBF5A2C1855AE00D1ECA6 /* ShortcutRecorder */ = {

--- a/Swift Shift/packages/CGEventSupervisor/LICENSE
+++ b/Swift Shift/packages/CGEventSupervisor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Stephan Casas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Swift Shift/packages/CGEventSupervisor/Package.swift
+++ b/Swift Shift/packages/CGEventSupervisor/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "CGEventSupervisor",
+    products: [
+        .library(
+            name: "CGEventSupervisor",
+            targets: ["CGEventSupervisor"]),
+    ],
+    targets: [
+        .target(
+            name: "CGEventSupervisor",
+            dependencies: []),
+    ]
+)

--- a/Swift Shift/packages/CGEventSupervisor/README.md
+++ b/Swift Shift/packages/CGEventSupervisor/README.md
@@ -1,0 +1,9 @@
+# CGEventSupervisor
+
+Originally by [Stephan Casas](https://github.com/stephancasas) — [CGEventSupervisor](https://github.com/stephancasas/CGEventSupervisor)
+
+Vendored into SwiftShift with the following fixes:
+- Proper Mach port teardown (run loop source removal + `CFMachPortInvalidate`)
+- Re-enable tap on `kCGEventTapDisabledByTimeout` / `kCGEventTapDisabledByUserInput`
+
+MIT License.

--- a/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor+Callback.swift
+++ b/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor+Callback.swift
@@ -1,0 +1,76 @@
+//
+//  CGEventSupervisor+Callback.swift
+//  
+//
+//  Created by Stephan Casas on 8/6/23.
+//
+
+import Cocoa;
+import Foundation;
+
+/// The main event callback which will perform casting
+/// for `CGEvent` to `NSEvent` and resolution of the
+/// given opaque pointer into `CGEventSupervisor`.
+///
+internal func CGEventSupervisorCallback(
+    _  eventTap: CGEventTapProxy,
+    _ eventType: CGEventType,
+    _     event: CGEvent,
+    _  userData: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    guard
+        let supervisorRef = userData
+    else {
+        return Unmanaged.passUnretained(event);
+    }
+    
+    let supervisor = Unmanaged<CGEventSupervisor>
+        .fromOpaque(supervisorRef)
+        .takeUnretainedValue();
+    
+    /// Handle disabled-tap events from the WindowServer.
+    /// These are sent when macOS kills the tap due to timeout, user input,
+    /// or system state changes (sleep, display reconfiguration, etc.).
+    /// Without this handler, the tap dies silently and stays dead until
+    /// the app is restarted.
+    if eventType == .tapDisabledByTimeout || eventType == .tapDisabledByUserInput {
+        guard let tap = supervisor.eventTapMachPort else {
+            return nil
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+        return nil
+    }
+
+    var bubbles = true;
+    for subscriber in supervisor.cgEventSubscribers.values {
+        if subscriber.events.contains(event.type){
+            subscriber.callback(event);
+            bubbles = !event.supervisorShouldCancel;
+        }
+        if !bubbles { return nil }
+    }
+    
+    /// Is the event eligible for casting to `NSEvent`?
+    ///
+    if event.type.rawValue > 0,
+       event.type.rawValue <= kCGEventLastUniversalType.rawValue,
+       supervisor.nsEventSubscribers.count > 0,
+       let nsEvent = NSEvent(cgEvent: event) {
+        
+        for subscriber in supervisor.nsEventSubscribers.values {
+            if subscriber.events.contains(event.type) {
+                subscriber.callback(nsEvent);
+                bubbles = !nsEvent.supervisorShouldCancel;
+            }
+            if !bubbles { return nil }
+        }
+        
+    }
+    
+    return Unmanaged.passUnretained(event);
+}
+
+/// The last-supported universal event type in the enumerations
+/// of `NSEvent.EventType` and `CGEventType`.
+///
+fileprivate let kCGEventLastUniversalType: CGEventType = .otherMouseDragged;

--- a/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor+Setup.swift
+++ b/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor+Setup.swift
@@ -1,0 +1,64 @@
+//
+//  CGEventSupervisor+Setup.swift
+//  
+//
+//  Created by Stephan Casas on 8/6/23.
+//
+
+import Cocoa;
+import Foundation;
+
+extension CGEventSupervisor {
+
+    /// Setup the event tap and receiving mach port for subscription
+    /// to the currently-subscribed event types.
+    ///
+    internal func setup() {
+        self.teardown();
+        
+        if self.totalSubscribers == 0 { return }
+        
+        guard let eventTapMachPort = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: self.eventMask,
+            callback: CGEventSupervisorCallback,
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            NSLog("[CGEventSupervisor]: Could not allocate the required mach port for CGEventTap.")
+            return;
+        }
+        
+        let runLoop = CFRunLoopGetCurrent();
+        let runLoopSrc = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTapMachPort, 0);
+        
+        CFRunLoopAddSource(runLoop, runLoopSrc, .commonModes);
+        CGEvent.tapEnable(tap: eventTapMachPort, enable: true);
+        
+        self.eventTapMachPort = eventTapMachPort;
+        self.eventTapRunLoopSource = runLoopSrc;
+    }
+    
+    /// Disable the event tap, and dispose of the receiving mach port.
+    ///
+    internal func teardown() {
+        if let src = self.eventTapRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), src, .commonModes)
+            self.eventTapRunLoopSource = nil
+        }
+        guard let eventTapMachPort = self.eventTapMachPort else { return }
+        CGEvent.tapEnable(tap: eventTapMachPort, enable: false);
+        CFMachPortInvalidate(eventTapMachPort)
+        self.eventTapMachPort = nil;
+    }
+
+    /// The `CGEventTap` mask/filter.
+    ///
+    var eventMask: CGEventMask {
+        CGEventMask(self.subscribedEvents.reduce(0, {
+            $0 | (1 << $1.rawValue)
+        }))
+    }
+    
+}

--- a/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor+Subscribers.swift
+++ b/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor+Subscribers.swift
@@ -1,0 +1,118 @@
+//
+//  CGEventSupervisor+Subscribers.swift
+//  
+//
+//  Created by Stephan Casas on 8/6/23.
+//
+
+import Cocoa;
+import Foundation;
+
+// MARK: - Subscribe/Unsubscribe
+
+public extension CGEventSupervisor {
+    
+    /// Register a subscription to global `NSEvent` events of
+    /// the given type.
+    /// - Parameters:
+    ///   - subscriber: The unique name of the subscriber.
+    ///   - events: The event types to which the subscriber will subscribe.
+    ///   - callback: The callback which will handle the subscribed event types.
+    func subscribe(
+        as subscriber: String,
+        to events: EventDescriptor<NSEvent.EventType>,
+        using callback: @escaping NSEventCallback
+    ) {
+        if events.rawValue.isEmpty { return }
+        
+        let needsSetup = !events.rawValue.allSatisfy({
+            self.subscribedEvents.contains($0)
+        });
+        
+        self.__nsEventSubscribers.updateValue(
+            (callback, events.rawValue), forKey: subscriber);
+        
+        if needsSetup { self.setup() }
+    }
+    
+    /// Register a subscription to global `CGEvent` events of
+    /// the given type.
+    /// - Parameters:
+    ///   - subscriber: The unique name of the subscriber.
+    ///   - events: The event types to which the subscriber will subscribe.
+    ///   - callback: The callback which will handle the subscribed event types.
+    func subscribe(
+        as subscriber: String,
+        to events: EventDescriptor<CGEventType>,
+        using callback: @escaping CGEventCallback
+    ) {
+        if events.rawValue.isEmpty { return }
+        
+        let needsSetup = !events.rawValue.allSatisfy({
+            self.subscribedEvents.contains($0)
+        });
+        
+        self.__cgEventSubscribers.updateValue(
+            (callback, events.rawValue), forKey: subscriber);
+        
+        if needsSetup { self.setup() }
+    }
+    
+    /// Cancel the named subscriber's event subscription.
+    ///
+    func cancel(subscriber: String) {
+        let preSubscribedEvents = self.subscribedEvents;
+        
+        self.__nsEventSubscribers.removeValue(forKey: subscriber);
+        self.__cgEventSubscribers.removeValue(forKey: subscriber);
+        
+        let postSubscribedEvents = self.subscribedEvents;
+        let needsSetup = !preSubscribedEvents.allSatisfy({
+            postSubscribedEvents.contains($0)
+        });
+        
+        /// Remove events from the mask which no longer
+        /// have any subscribers, or disable the tap if
+        /// no subscribers remain.
+        ///
+        if needsSetup { self.setup() }
+    }
+    
+    /// Cancel all event subscriptions and dispose of the `CGEventTap`.
+    ///
+    func cancelAll() {
+        self.__cgEventSubscribers.removeAll();
+        self.__nsEventSubscribers.removeAll();
+        
+        self.teardown();
+    }
+    
+}
+
+// MARK: - Computed
+
+public extension CGEventSupervisor {
+    
+    /// All event types having at least one subscriber.
+    ///
+    var subscribedEvents: [CGEventType] {
+        var allEvents = self.nsEventSubscribers.values.flatMap({ $0.events });
+        allEvents.append(contentsOf: self.cgEventSubscribers.values.flatMap({ $0.events }));
+        
+        var uniqueEvents = [CGEventType]();
+        for event in allEvents {
+            if uniqueEvents.contains(event) { continue }
+            uniqueEvents.append(event);
+        }
+        
+        return uniqueEvents;
+    }
+    
+    /// The total number of event subscribers.
+    ///
+    var totalSubscribers: Int {
+        self.nsEventSubscribers.count + self.cgEventSubscribers.count
+    }
+    
+}
+

--- a/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor+Types.swift
+++ b/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor+Types.swift
@@ -1,0 +1,96 @@
+//
+//  CGEventSupervisor+Types.swift
+//  
+//
+//  Created by Stephan Casas on 8/6/23.
+//
+
+import Cocoa;
+import Foundation;
+
+// MARK: - Subscribers
+
+public extension CGEventSupervisor {
+    
+    typealias NSEventCallback = (_ event: NSEvent) -> Void
+    typealias CGEventCallback = (_ event: CGEvent) -> Void
+    
+    typealias NSEventSubscriber = (callback: NSEventCallback, events: [CGEventType]);
+    typealias CGEventSubscriber = (callback: CGEventCallback, events: [CGEventType]);
+    
+    typealias NSEventSubscriberStore = [String: NSEventSubscriber];
+    typealias CGEventSubscriberStore = [String: CGEventSubscriber];
+
+}
+
+// MARK: - Events
+
+public extension CGEventSupervisor {
+    
+    /// A type which describes both the events to which a subscriber
+    /// will subscribe as well as the format in which the event is
+    /// expected — `NSEvent` or `CGEvent`.
+    ///
+    struct EventDescriptor<T>: RawRepresentable {
+        public var rawValue: [CGEventType];
+        
+        public init(rawValue: [CGEventType]) {
+            self.rawValue = rawValue;
+        }
+    }
+    
+}
+
+//MARK: - CGEvent
+
+public extension CGEventSupervisor.EventDescriptor where T == CGEventType {
+    
+    /// The subscriber receives events from the `CGEventTap` which are of the
+    /// given event types.
+    ///
+    static func cgEvents(_ events: CGEventType...) -> Self {
+        .init(rawValue: events)
+    }
+    
+}
+
+// MARK: - NSEvent
+
+public extension CGEventSupervisor.EventDescriptor where T == NSEvent.EventType {
+    
+    /// The subscriber receives events from the `CGEventTap` which are of the
+    /// given universal event types and which have been cast to `NSEvent`.
+    ///
+    static func nsEvents(_ events: UniversalEventType...) -> Self {
+        .init(rawValue: events.compactMap({ CGEventType(rawValue: $0.rawValue)} ))
+    }
+    
+    /// Events available in both the `CGEventType` and `NSEvent.EventType`
+    /// enumerations.
+    ///
+    enum UniversalEventType: UInt32 {
+        /* Mouse events. */
+        case     leftMouseDown = 1;
+        case       leftMouseUp = 2;
+        case    rightMouseDown = 3;
+        case      rightMouseUp = 4;
+        case        mouseMoved = 5;
+        case  leftMouseDragged = 6;
+        case rightMouseDragged = 7;
+        
+        /* Keyboard events. */
+        case      keyDown = 10;
+        case        keyUp = 11;
+        case flagsChanged = 12;
+        
+        /* Specialized control devices. */
+        case       scrollWheel = 22;
+        case     tabletPointer = 23;
+        case   tabletProximity = 24;
+        case    otherMouseDown = 25;
+        case      otherMouseUp = 26;
+        case otherMouseDragged = 27;
+    }
+    
+}
+

--- a/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor.swift
+++ b/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/CGEventSupervisor.swift
@@ -1,0 +1,25 @@
+//
+//  CGEventSupervisor.swift
+//
+//  Created by Stephan Casas on 4/24/23.
+//
+
+import Foundation;
+
+public class CGEventSupervisor {
+    
+    public static let shared = CGEventSupervisor();
+    
+    // MARK: - Public
+    
+    var nsEventSubscribers: NSEventSubscriberStore { self.__nsEventSubscribers }
+    var cgEventSubscribers: CGEventSubscriberStore { self.__cgEventSubscribers }
+    
+    // MARK: - Internal
+    
+    internal var     eventTapMachPort:            CFMachPort? = nil;
+    internal var     eventTapRunLoopSource:        CFRunLoopSource? = nil;
+    internal var __nsEventSubscribers: NSEventSubscriberStore = [:];
+    internal var __cgEventSubscribers: CGEventSubscriberStore = [:];
+    
+}

--- a/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/Extensions/CGEvent.swift
+++ b/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/Extensions/CGEvent.swift
@@ -1,0 +1,40 @@
+//
+//  CGEvent.swift
+//  
+//
+//  Created by Stephan Casas on 8/6/23.
+//
+
+import Cocoa;
+import Foundation
+
+fileprivate var kSupervisedCGEventShouldCancelKey: String = "__SupervisedCGEventShouldCancel";
+
+public extension CGEvent {
+    
+    /// If the event is supervised by `CGEventSupervisor`, setting this
+    /// to `true` will stop the event from propagating to the next-installed
+    /// callback and will prevent the event from reaching its intended target.
+    ///
+    internal var supervisorShouldCancel: Bool {
+        set { objc_setAssociatedObject(
+            self,
+            &kSupervisedCGEventShouldCancelKey,
+            newValue,
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        ) }
+        get { objc_getAssociatedObject(
+            self,
+            &kSupervisedCGEventShouldCancelKey
+        ) as? Bool ?? false }
+    }
+    
+    /// If the event is supervised by `CGEventSupervisor`, end
+    /// propagation into the next subscriber and do not
+    /// send the event to its user-intended target.
+    ///
+    func cancel() {
+        self.supervisorShouldCancel = true;
+    }
+    
+}

--- a/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/Extensions/NSEvent.swift
+++ b/Swift Shift/packages/CGEventSupervisor/Sources/CGEventSupervisor/Extensions/NSEvent.swift
@@ -1,0 +1,40 @@
+//
+//  NSEvent.swift
+//  
+//
+//  Created by Stephan Casas on 8/6/23.
+//
+
+import Cocoa;
+import Foundation;
+
+fileprivate var kSupervisedNSEventShouldCancelKey: String = "__SupervisedNSEventShouldCancel";
+
+public extension NSEvent {
+    
+    /// If the event is supervised by `CGEventSupervisor`, setting this
+    /// to `true` will stop the event from propagating to the next-installed
+    /// callback and will prevent the event from reaching its intended target.
+    ///
+    internal var supervisorShouldCancel: Bool {
+        set { objc_setAssociatedObject(
+            self,
+            &kSupervisedNSEventShouldCancelKey,
+            newValue,
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        ) }
+        get { objc_getAssociatedObject(
+            self,
+            &kSupervisedNSEventShouldCancelKey
+        ) as? Bool ?? false }
+    }
+    
+    /// If the event is supervised by `CGEventSupervisor`, end
+    /// propagation into the next subscriber and do not
+    /// send the event to its user-intended target.
+    ///
+    func cancel() {
+        self.supervisorShouldCancel = true;
+    }
+    
+}

--- a/Swift Shift/src/Manager/ShortcutsManager.swift
+++ b/Swift Shift/src/Manager/ShortcutsManager.swift
@@ -178,6 +178,7 @@ class ShortcutsManager {
   private(set) var activeShortcuts: [ShortcutType: Bool] = [:]
   private var mouseSubscriptions: Set<String> = []
   private var workspaceNotificationObserver: Any?
+  private var systemEventObservers: [Any] = []
   var hasActiveShortcut: Bool {
     activeShortcuts.values.contains(true)
   }
@@ -187,11 +188,13 @@ class ShortcutsManager {
       activeShortcuts[type] = false
     }
     registerForWorkspaceNotifications()
+    registerForSystemEventNotifications()
     updateGlobalShortcuts()
   }
 
   deinit {
     unregisterForWorkspaceNotifications()
+    unregisterForSystemEventNotifications()
   }
 
   private func registerForWorkspaceNotifications() {
@@ -209,6 +212,67 @@ class ShortcutsManager {
       NSWorkspace.shared.notificationCenter.removeObserver(observer)
       workspaceNotificationObserver = nil
     }
+  }
+
+  /// Register for system events that can silently disable the CGEventTap.
+  /// macOS kills event taps on sleep/wake, display changes, and session
+  /// transitions without notifying the app. We rebuild all input hooks
+  /// when these occur — the same effect as restarting the app.
+  private func registerForSystemEventNotifications() {
+    let nc = NSWorkspace.shared.notificationCenter
+
+    let wakeObserver = nc.addObserver(
+      forName: NSWorkspace.didWakeNotification,
+      object: nil,
+      queue: .main) { [weak self] _ in
+        self?.rebuildAllInputHooks()
+      }
+    systemEventObservers.append(wakeObserver)
+
+    let sessionObserver = nc.addObserver(
+      forName: NSWorkspace.sessionDidBecomeActiveNotification,
+      object: nil,
+      queue: .main) { [weak self] _ in
+        self?.rebuildAllInputHooks()
+      }
+    systemEventObservers.append(sessionObserver)
+
+    let screensObserver = NotificationCenter.default.addObserver(
+      forName: NSApplication.didChangeScreenParametersNotification,
+      object: nil,
+      queue: .main) { [weak self] _ in
+        self?.rebuildAllInputHooks()
+      }
+    systemEventObservers.append(screensObserver)
+  }
+
+  private func unregisterForSystemEventNotifications() {
+    let workspaceCenter = NSWorkspace.shared.notificationCenter
+    let defaultCenter = NotificationCenter.default
+    for observer in systemEventObservers {
+      workspaceCenter.removeObserver(observer)
+      defaultCenter.removeObserver(observer)
+    }
+    systemEventObservers = []
+  }
+
+  /// Fully tear down and rebuild all input interception infrastructure.
+  /// Call this when the CGEventTap may have been disabled by the system
+  /// (sleep, display change, session lock, etc.).
+  private func rebuildAllInputHooks() {
+    // Clear active shortcut state — after a system event we can't
+    // trust that modifier keys are still held. Let next key event
+    // re-establish tracking naturally.
+    for type in ShortcutType.allCases where activeShortcuts[type] == true {
+      let action: MouseAction = type == .move ? .move : .resize
+      MouseTracker.shared.stopTracking(for: action)
+      cleanupMouseSubscriptions(action: action)
+      activeShortcuts[type] = false
+    }
+
+    CGEventSupervisor.shared.cancelAll()
+    updateGlobalShortcuts()
+    MouseChordActionManager.shared.forceRebuild()
   }
 
   private func handleSpaceChange() {
@@ -718,9 +782,11 @@ class MouseChordActionManager {
   private var leftButtonIsDown = false
   private var rightButtonIsDown = false
   private var workspaceNotificationObserver: Any?
+  private var healthCheckTimer: Timer?
 
   private init() {
     registerForWorkspaceNotifications()
+    startHealthCheckTimer()
   }
 
   deinit {
@@ -738,7 +804,34 @@ class MouseChordActionManager {
     }
   }
 
+  /// Force teardown and rebuild of mouse-only chord subscriptions.
+  /// Use after system events (sleep, display change, session lock)
+  /// that may have disabled the CGEventTap without our knowledge.
+  func forceRebuild() {
+    stopChordAction(resetButtons: true)
+    unsubscribe()
+    cachedMouseOnlyAction = nil
+    updateSubscriptions()
+  }
+
+  /// Periodic health check for the CGEventTap. macOS can silently disable
+  /// taps during Secure Input sessions (password prompts, sudo in Terminal)
+  /// with no notification. This timer ensures we recover within 60 seconds.
+  private func startHealthCheckTimer() {
+    healthCheckTimer?.invalidate()
+    healthCheckTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+      guard let self = self, self.isSubscribed else { return }
+      // Don't rebuild mid-gesture — would drop pending mouse events
+      // activeAction is set during an active chord drag;
+      // pendingInitialMouseDown is set between the first and second button press
+      guard self.activeAction == nil, self.pendingInitialMouseDown == nil else { return }
+      self.forceRebuild()
+    }
+  }
+
   func cleanup() {
+    healthCheckTimer?.invalidate()
+    healthCheckTimer = nil
     stopChordAction(resetButtons: true)
     unsubscribe()
     unregisterForWorkspaceNotifications()


### PR DESCRIPTION
## Problem
SwiftShift's mouse-click shortcuts (Command+click for Move, Command+right-click for Resize) use a CGEventTap to intercept mouse events. macOS silently disables event taps on sleep/wake, display changes, session lock, and slow callbacks — but SwiftShift had no recovery mechanism. A dead tap causes system-wide input lag because CGEventTaps are synchronous (WindowServer pauses all input until the callback returns).

Closes #167.

## Root Cause
The reporter uses Command+click for Move and Command+right-click for Resize. Each shortcut press creates CGEventSupervisor subscriptions which create a CGEventTap. The tap dies silently on system events, and without recovery the tap stays dead — causing the system-wide input delay. Restarting the app works because it creates a fresh tap.

## Fixes
1. **CGEventSupervisor vendored & fixed** — proper Mach port teardown (run loop source removal + CFMachPortInvalidate), auto-reenable tap on disabled-by-timeout/user-input events
2. **System event recovery** — observers for , ,  trigger full rebuild of all input hooks
3. **** — fixes stale  flag after  so mouse-only chords recover properly
4. **Active shortcut state cleared on recovery** — prevents stale modifier-key state from blocking future activations
5. **60s health check timer** — catches tap death from Secure Input (password prompts, sudo) via periodic 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved system-wide mouse input degradation (Issue 167) caused by the event tap being silently disabled during sleep/wake, display changes, session lock, and related conditions.
  * Added stronger automatic recovery that re-enables event handling and rebuilds input hooks when tap health monitoring detects failure.
* **Documentation**
  * Updated the included fix documentation for the vendored event-supervision component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->