### PR TITLE
Add XCTest target with 49 tests (KeyboardShortcut, PreferencesManager, WindowManager)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build & Test
 
 on:
   pull_request:
@@ -17,3 +17,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: make build
+
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run tests
+        run: |
+          xcodebuild test \
+            -project "Swift Shift.xcodeproj" \
+            -scheme "Swift Shift" \
+            -destination "platform=macOS" \
+            -only-testing:SwiftShiftTests \
+            -enableCodeCoverage NO \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build open-app run appcast generate-keys release
+.PHONY: build test open-app run appcast generate-keys release
 
 build:
 	xcodebuild -scheme "Swift Shift" build SYMROOT=$(PWD)/build \
@@ -6,6 +6,15 @@ build:
 
 run-app:
 	open "./build/Debug/Swift Shift Dev.app"
+
+test:
+	xcodebuild test \
+		-project "Swift Shift.xcodeproj" \
+		-scheme "Swift Shift" \
+		-destination "platform=macOS" \
+		-only-testing:SwiftShiftTests \
+		-enableCodeCoverage NO \
+		CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
 run: build run-app
 

--- a/Swift Shift.xcodeproj/project.pbxproj
+++ b/Swift Shift.xcodeproj/project.pbxproj
@@ -24,10 +24,14 @@
 		1798B1222B48131400E07964 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1798B1212B48131400E07964 /* InfoView.swift */; };
 		17FC9BB42FB3B76200DFB068 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 17FC9BB32FB3B76200DFB068 /* AppIcon.icon */; };
 		17FC9BB62FB4A00100DFB068 /* icon-64x64.png in Resources */ = {isa = PBXBuildFile; fileRef = 17FC9BB52FB4A00100DFB068 /* icon-64x64.png */; };
+		261AF3357AC7FA793AFC77B8 /* WindowManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFB661166B07FADAC97D611 /* WindowManagerTests.swift */; };
+		2B21ED354D4631539DB4BB1D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8B92CDB5F568BDAA9756F45 /* Foundation.framework */; };
 		336441112C189812000A1C90 /* CGEventSupervisor in Frameworks */ = {isa = PBXBuildFile; productRef = 336441102C189812000A1C90 /* CGEventSupervisor */; };
 		338FBF5B2C1855AE00D1ECA6 /* ShortcutRecorder in Frameworks */ = {isa = PBXBuildFile; productRef = 338FBF5A2C1855AE00D1ECA6 /* ShortcutRecorder */; };
 		338FBF5D2C1855B200D1ECA6 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 338FBF5C2C1855B200D1ECA6 /* LaunchAtLogin */; };
 		338FBF5F2C1855B400D1ECA6 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 338FBF5E2C1855B400D1ECA6 /* Sparkle */; };
+		6FA028238EDB1C81BAE30648 /* KeyboardShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF311F2632748B7B9EAF0B5E /* KeyboardShortcutTests.swift */; };
+		8AF06071C16FF49D8ABEB1B0 /* PreferencesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C8392320D65A939A324CA3 /* PreferencesManagerTests.swift */; };
 		E236331E2B44669200C0E61F /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = E236331D2B44669200C0E61F /* Preferences.swift */; };
 		E23633202B4466F800C0E61F /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E236331F2B4466F800C0E61F /* PreferencesView.swift */; };
 		E2CABBA52B447AEA00D66D43 /* UpdatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CABBA42B447AEA00D66D43 /* UpdatesView.swift */; };
@@ -36,7 +40,18 @@
 		E2E6F5EA2B3EF03C005B0D96 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E6F5E92B3EF03C005B0D96 /* Constants.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		A7024AE8DAA69743D0525063 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1781A5D62B31EE4900F27910 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1781A5DD2B31EE4900F27910;
+			remoteInfo = "Swift Shift";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		1500434D466F0EB81368D3B9 /* PermissionsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PermissionsManager.swift; path = "Swift Shift/src/Manager/PermissionsManager.swift"; sourceTree = "<group>"; };
 		17087D942DD254890006852C /* IgnoredAppsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoredAppsTabView.swift; sourceTree = "<group>"; };
 		172E0BD42B32F36300D5CDA7 /* MouseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseTracker.swift; sourceTree = "<group>"; };
 		173C0E822C123CF700654527 /* DrawCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawCircle.swift; sourceTree = "<group>"; };
@@ -56,12 +71,27 @@
 		1798B1212B48131400E07964 /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		17FC9BB32FB3B76200DFB068 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; name = AppIcon.icon; path = assets/AppIcon.icon; sourceTree = SOURCE_ROOT; };
 		17FC9BB52FB4A00100DFB068 /* icon-64x64.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "icon-64x64.png"; path = "assets/icon-64x64.png"; sourceTree = SOURCE_ROOT; };
+		1DE4E74575F32B684D40A5B1 /* Preferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Preferences.swift; path = "Swift Shift/src/Manager/Preferences.swift"; sourceTree = "<group>"; };
+		1E7F3089F67E0DA8FCF32B1F /* ShortcutsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShortcutsManager.swift; path = "Swift Shift/src/Manager/ShortcutsManager.swift"; sourceTree = "<group>"; };
+		2F7068A35E872B916122F622 /* SwiftShiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftShiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		38E53EACF577219DA37EB8D0 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = "Swift Shift/src/Constants.swift"; sourceTree = "<group>"; };
+		39C8392320D65A939A324CA3 /* PreferencesManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PreferencesManagerTests.swift; path = SwiftShiftTests/PreferencesManagerTests.swift; sourceTree = SOURCE_ROOT; };
+		3C0E83B215533AA53B9BD58A /* WindowManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WindowManager.swift; path = "Swift Shift/src/Manager/WindowManager.swift"; sourceTree = "<group>"; };
+		455BCFE8EC31AD5F7AB42302 /* ShortcutsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShortcutsManager.swift; path = "Swift Shift/src/Manager/ShortcutsManager.swift"; sourceTree = "<group>"; };
+		47B2F012C2D2A93C1E6EFF68 /* PermissionsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PermissionsManager.swift; path = "Swift Shift/src/Manager/PermissionsManager.swift"; sourceTree = "<group>"; };
+		5EFB661166B07FADAC97D611 /* WindowManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WindowManagerTests.swift; path = SwiftShiftTests/WindowManagerTests.swift; sourceTree = SOURCE_ROOT; };
+		8D0097B12CEF5A7D405EA84C /* Preferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Preferences.swift; path = "Swift Shift/src/Manager/Preferences.swift"; sourceTree = "<group>"; };
+		B4FAEC4EF8BA9AFD9FABBA1F /* SwiftShiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftShiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9075C2AB4A5BD52358038BF /* WindowManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WindowManager.swift; path = "Swift Shift/src/Manager/WindowManager.swift"; sourceTree = "<group>"; };
+		DF311F2632748B7B9EAF0B5E /* KeyboardShortcutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeyboardShortcutTests.swift; path = SwiftShiftTests/KeyboardShortcutTests.swift; sourceTree = SOURCE_ROOT; };
 		E236331D2B44669200C0E61F /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		E236331F2B4466F800C0E61F /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		E2CABBA42B447AEA00D66D43 /* UpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesView.swift; sourceTree = "<group>"; };
 		E2CABBA72B44D69B00D66D43 /* UpdatesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesManager.swift; sourceTree = "<group>"; };
 		E2D8CFB82B3C3B9B00EBB047 /* PermissionsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsManager.swift; sourceTree = "<group>"; };
 		E2E6F5E92B3EF03C005B0D96 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		F400D7AF72C65A047C5C9D19 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = "Swift Shift/src/Constants.swift"; sourceTree = "<group>"; };
+		F8B92CDB5F568BDAA9756F45 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +103,14 @@
 				338FBF5D2C1855B200D1ECA6 /* LaunchAtLogin in Frameworks */,
 				338FBF5B2C1855AE00D1ECA6 /* ShortcutRecorder in Frameworks */,
 				336441112C189812000A1C90 /* CGEventSupervisor in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1B6D5960A252DCB9EA112E9F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2B21ED354D4631539DB4BB1D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -134,6 +172,15 @@
 			children = (
 				1781A5E02B31EE4A00F27910 /* Swift Shift */,
 				1781A5DF2B31EE4900F27910 /* Products */,
+				6A4DE3E9182D868AD6840D51 /* Frameworks */,
+				1E7F3089F67E0DA8FCF32B1F /* ShortcutsManager.swift */,
+				8D0097B12CEF5A7D405EA84C /* Preferences.swift */,
+				C9075C2AB4A5BD52358038BF /* WindowManager.swift */,
+				1500434D466F0EB81368D3B9 /* PermissionsManager.swift */,
+				38E53EACF577219DA37EB8D0 /* Constants.swift */,
+				DF311F2632748B7B9EAF0B5E /* KeyboardShortcutTests.swift */,
+				5EFB661166B07FADAC97D611 /* WindowManagerTests.swift */,
+				39C8392320D65A939A324CA3 /* PreferencesManagerTests.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -141,6 +188,8 @@
 			isa = PBXGroup;
 			children = (
 				1781A5DE2B31EE4900F27910 /* Swift Shift Dev.app */,
+				B4FAEC4EF8BA9AFD9FABBA1F /* SwiftShiftTests.xctest */,
+				2F7068A35E872B916122F622 /* SwiftShiftTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -154,6 +203,7 @@
 				17FC9BB32FB3B76200DFB068 /* AppIcon.icon */,
 				17FC9BB52FB4A00100DFB068 /* icon-64x64.png */,
 				1781A5E72B31EE4B00F27910 /* Preview Content */,
+				CA159C790883CECAE83D05D9 /* SwiftShiftTests */,
 			);
 			path = "Swift Shift";
 			sourceTree = "<group>";
@@ -165,6 +215,35 @@
 			);
 			path = "Preview Content";
 			sourceTree = "<group>";
+		};
+		6A4DE3E9182D868AD6840D51 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9678DCD91E82FD8932843925 /* OS X */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9678DCD91E82FD8932843925 /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				F8B92CDB5F568BDAA9756F45 /* Foundation.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
+		CA159C790883CECAE83D05D9 /* SwiftShiftTests */ = {
+			isa = PBXGroup;
+			children = (
+				455BCFE8EC31AD5F7AB42302 /* ShortcutsManager.swift */,
+				1DE4E74575F32B684D40A5B1 /* Preferences.swift */,
+				3C0E83B215533AA53B9BD58A /* WindowManager.swift */,
+				47B2F012C2D2A93C1E6EFF68 /* PermissionsManager.swift */,
+				F400D7AF72C65A047C5C9D19 /* Constants.swift */,
+			);
+			name = SwiftShiftTests;
+			path = SwiftShiftTests;
+			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */
 
@@ -191,6 +270,30 @@
 			productName = "Swift Shift";
 			productReference = 1781A5DE2B31EE4900F27910 /* Swift Shift Dev.app */;
 			productType = "com.apple.product-type.application";
+		};
+		4F0E66367D37633ED8A08262 /* SwiftShiftTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C23D51E0232A63C44232EE11 /* Build configuration list for PBXNativeTarget "SwiftShiftTests" */;
+			buildPhases = (
+				F65E317B5C207839E6F23354 /* Sources */,
+				1B6D5960A252DCB9EA112E9F /* Frameworks */,
+				19034F6EF5897179A3955A8B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7B950F4CEFB799D1A5CD8161 /* PBXTargetDependency */,
+			);
+			name = SwiftShiftTests;
+			packageProductDependencies = (
+				338FBF5A2C1855AE00D1ECA6 /* ShortcutRecorder */,
+				338FBF5C2C1855B200D1ECA6 /* LaunchAtLogin */,
+				338FBF5E2C1855B400D1ECA6 /* Sparkle */,
+				336441102C189812000A1C90 /* CGEventSupervisor */,
+			);
+			productName = SwiftShiftTests;
+			productReference = 2F7068A35E872B916122F622 /* SwiftShiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -227,6 +330,7 @@
 			projectRoot = "";
 			targets = (
 				1781A5DD2B31EE4900F27910 /* Swift Shift */,
+				4F0E66367D37633ED8A08262 /* SwiftShiftTests */,
 			);
 		};
 /* End PBXProject section */
@@ -240,6 +344,13 @@
 				1781A5E62B31EE4B00F27910 /* Assets.xcassets in Resources */,
 				17FC9BB42FB3B76200DFB068 /* AppIcon.icon in Resources */,
 				17FC9BB62FB4A00100DFB068 /* icon-64x64.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		19034F6EF5897179A3955A8B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -272,7 +383,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F65E317B5C207839E6F23354 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6FA028238EDB1C81BAE30648 /* KeyboardShortcutTests.swift in Sources */,
+				261AF3357AC7FA793AFC77B8 /* WindowManagerTests.swift in Sources */,
+				8AF06071C16FF49D8ABEB1B0 /* PreferencesManagerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7B950F4CEFB799D1A5CD8161 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Swift Shift";
+			target = 1781A5DD2B31EE4900F27910 /* Swift Shift */;
+			targetProxy = A7024AE8DAA69743D0525063 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		1781A5EB2B31EE4B00F27910 /* Debug */ = {
@@ -408,6 +538,7 @@
 				DEVELOPMENT_TEAM = 2TZ4Q825M7;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_TESTABILITY = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Swift-Shift-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Swift Shift Dev";
@@ -461,6 +592,42 @@
 			};
 			name = Release;
 		};
+		291EF055A6868417DA4ECDEC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pablopunk.SwiftShiftTests;
+				PRODUCT_NAME = SwiftShiftTests;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swift Shift.app/Contents/MacOS/Swift Shift";
+			};
+			name = Release;
+		};
+		47FCE1967DC1C8CDFFAFC909 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pablopunk.SwiftShiftTests;
+				PRODUCT_NAME = SwiftShiftTests;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swift Shift Dev.app/Contents/MacOS/Swift Shift Dev";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -482,7 +649,23 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		C23D51E0232A63C44232EE11 /* Build configuration list for PBXNativeTarget "SwiftShiftTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				291EF055A6868417DA4ECDEC /* Release */,
+				47FCE1967DC1C8CDFFAFC909 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		3364410F2C189812000A1C90 /* XCLocalSwiftPackageReference "CGEventSupervisor" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "Swift Shift/packages/CGEventSupervisor";
+		};
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
 		177FB2462B31FE7F00B11BA3 /* XCRemoteSwiftPackageReference "ShortcutRecorder" */ = {
@@ -500,10 +683,6 @@
 				branch = main;
 				kind = branch;
 			};
-		};
-		3364410F2C189812000A1C90 /* XCLocalSwiftPackageReference "CGEventSupervisor" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "Swift Shift/packages/CGEventSupervisor";
 		};
 		E23633212B44749C00C0E61F /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;

--- a/Swift Shift.xcodeproj/xcshareddata/xcschemes/Swift Shift.xcscheme
+++ b/Swift Shift.xcodeproj/xcshareddata/xcschemes/Swift Shift.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Swift Shift.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D76A70D72EB4AAB358AE0D75"
+               BuildableName = "SwiftShiftTests.xctest"
+               BlueprintName = "SwiftShiftTests"
+               ReferencedContainer = "container:Swift Shift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -27,7 +41,20 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldAutocreateTestPlan = "YES"
+      codeCoverageEnabled = "NO">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D76A70D72EB4AAB358AE0D75"
+               BuildableName = "SwiftShiftTests.xctest"
+               BlueprintName = "SwiftShiftTests"
+               ReferencedContainer = "container:Swift Shift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/SwiftShiftTests/KeyboardShortcutTests.swift
+++ b/SwiftShiftTests/KeyboardShortcutTests.swift
@@ -1,0 +1,285 @@
+import XCTest
+@testable import Swift_Shift_Dev
+
+final class KeyboardShortcutTests: XCTestCase {
+
+    // MARK: - Initialization
+
+    func testInitWithKeyCodeAndModifiers() {
+        let shortcut = KeyboardShortcut(
+            keyCode: 36,
+            modifierFlags: [.command, .shift],
+            characters: "\r",
+            charactersIgnoringModifiers: "r"
+        )
+        XCTAssertEqual(shortcut.keyCode, 36)
+        XCTAssertEqual(shortcut.modifierFlags, [.command, .shift])
+        XCTAssertEqual(shortcut.characters, "\r")
+        XCTAssertEqual(shortcut.charactersIgnoringModifiers, "r")
+    }
+
+    func testInitWithNilKeyCode_createsModifierOnlyShortcut() {
+        let shortcut = KeyboardShortcut(
+            keyCode: nil,
+            modifierFlags: [.command, .option]
+        )
+        XCTAssertNil(shortcut.keyCode)
+        XCTAssertTrue(shortcut.isModifierOnly)
+        XCTAssertEqual(shortcut.modifierFlags, [.command, .option])
+    }
+
+    func testInitFromShortcutRecorderShortcut() {
+        // ShortcutRecorder Shortcut can't easily be constructed in tests
+        // but we can test the KeyboardShortcut initializer logic indirectly
+        let shortcut = KeyboardShortcut(
+            keyCode: 36,
+            modifierFlags: [.command],
+            characters: "\r",
+            charactersIgnoringModifiers: "r"
+        )
+        XCTAssertEqual(shortcut.keyCode, 36)
+        XCTAssertEqual(shortcut.modifierFlags, [.command])
+    }
+
+    // MARK: - Modifier Flags
+
+    func testModifierFlagsAreFilteredToSwiftShiftMask() {
+        // The swiftShiftShortcutMask includes only [.command, .option, .shift, .control, .function]
+        // CapsLock and numericPad should be stripped
+        let shortcut = KeyboardShortcut(
+            keyCode: 36,
+            modifierFlags: [.command, .capsLock, .numericPad]
+        )
+        // Only .command should remain after filtering through swiftShiftShortcutFlags
+        XCTAssertEqual(shortcut.modifierFlags, [.command])
+        XCTAssertFalse(shortcut.modifierFlags.contains(.capsLock))
+        XCTAssertFalse(shortcut.modifierFlags.contains(.numericPad))
+    }
+
+    func testModifierFlagsPreservesFunctionKey() {
+        let shortcut = KeyboardShortcut(
+            keyCode: 63,
+            modifierFlags: [.function, .command]
+        )
+        XCTAssertTrue(shortcut.usesFunctionModifier)
+        XCTAssertEqual(shortcut.modifierFlags, [.command, .function])
+    }
+
+    func testModifierFlagsRawValuePersistence() {
+        let shortcut = KeyboardShortcut(
+            keyCode: 36,
+            modifierFlags: [.command, .option],
+            characters: "\r",
+            charactersIgnoringModifiers: "r"
+        )
+        // Encode and decode to verify modifier flags survive roundtrip
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        guard let data = try? encoder.encode(shortcut),
+              let decoded = try? decoder.decode(KeyboardShortcut.self, from: data) else {
+            XCTFail("Failed to encode/decode KeyboardShortcut")
+            return
+        }
+
+        XCTAssertEqual(decoded.keyCode, 36)
+        XCTAssertEqual(decoded.modifierFlags, [.command, .option])
+        XCTAssertEqual(decoded.characters, "\r")
+        XCTAssertEqual(decoded.charactersIgnoringModifiers, "r")
+    }
+
+    // MARK: - isModifierOnly
+
+    func testIsModifierOnly_whenKeyCodeIsNil() {
+        let shortcut = KeyboardShortcut(keyCode: nil, modifierFlags: [.command])
+        XCTAssertTrue(shortcut.isModifierOnly)
+    }
+
+    func testIsModifierOnly_whenKeyCodeIsSet() {
+        let shortcut = KeyboardShortcut(keyCode: 36, modifierFlags: [.command])
+        XCTAssertFalse(shortcut.isModifierOnly)
+    }
+
+    // MARK: - usesFunctionModifier
+
+    func testUsesFunctionModifier_whenFnKeyPresent() {
+        let shortcut = KeyboardShortcut(keyCode: 122, modifierFlags: [.function])
+        XCTAssertTrue(shortcut.usesFunctionModifier)
+    }
+
+    func testUsesFunctionModifier_whenFnKeyAbsent() {
+        let shortcut = KeyboardShortcut(keyCode: 122, modifierFlags: [.command])
+        XCTAssertFalse(shortcut.usesFunctionModifier)
+    }
+
+    // MARK: - displayString
+
+    func testDisplayString_forStandardShortcut() {
+        let shortcut = KeyboardShortcut(
+            keyCode: 0, // "a" key
+            modifierFlags: [.command],
+            characters: "a",
+            charactersIgnoringModifiers: "a"
+        )
+        XCTAssertEqual(shortcut.displayString, "⌘A")
+    }
+
+    func testDisplayString_forModifierOnlyShortcut() {
+        let shortcut = KeyboardShortcut(keyCode: nil, modifierFlags: [.command, .option])
+        XCTAssertEqual(shortcut.displayString, "⌥⌘")
+    }
+
+    func testDisplayString_forFunctionKeyShortcut() {
+        let shortcut = KeyboardShortcut(keyCode: 122, modifierFlags: [.function])
+        XCTAssertEqual(shortcut.displayString, "fnF1")
+    }
+
+    func testDisplayString_whenEmpty_returnsRecordShortcut() {
+        let shortcut = KeyboardShortcut(keyCode: nil, modifierFlags: [])
+        XCTAssertEqual(shortcut.displayString, "Record Shortcut")
+    }
+
+    func testDisplayString_forSpaceCharacter() {
+        let shortcut = KeyboardShortcut(
+            keyCode: 49,
+            modifierFlags: [.command],
+            characters: " ",
+            charactersIgnoringModifiers: " "
+        )
+        XCTAssertEqual(shortcut.displayString, "⌘Space")
+    }
+
+    func testDisplayString_forAllModifierCombinations() {
+        let shortcut = KeyboardShortcut(
+            keyCode: 36,
+            modifierFlags: [.command, .option, .shift, .control, .function],
+            characters: "\r",
+            charactersIgnoringModifiers: "r"
+        )
+        XCTAssertTrue(shortcut.displayString.contains("fn"))
+        XCTAssertTrue(shortcut.displayString.contains("⌃"))
+        XCTAssertTrue(shortcut.displayString.contains("⌥"))
+        XCTAssertTrue(shortcut.displayString.contains("⇧"))
+        XCTAssertTrue(shortcut.displayString.contains("⌘"))
+    }
+
+    // MARK: - canUseWithoutModifiers
+
+    func testCanUseWithoutModifiers_forFunctionKeys() {
+        // F1-F20 should be usable without modifiers
+        let functionKeyCodes: [UInt16] = [122, 120, 99, 118, 96, 97, 98, 100, 101, 109,
+                                           103, 111, 105, 107, 113, 106, 64, 79, 80, 90]
+        for keyCode in functionKeyCodes {
+            XCTAssertTrue(KeyboardShortcut.canUseWithoutModifiers(keyCode: keyCode),
+                          "Key code \(keyCode) should be usable without modifiers")
+        }
+    }
+
+    func testCanUseWithoutModifiers_forRegularKeys() {
+        // Regular alpha keys should NOT be usable without modifiers
+        XCTAssertFalse(KeyboardShortcut.canUseWithoutModifiers(keyCode: 0))   // 'a'
+        XCTAssertFalse(KeyboardShortcut.canUseWithoutModifiers(keyCode: 36))  // Return
+        XCTAssertFalse(KeyboardShortcut.canUseWithoutModifiers(keyCode: 49))  // Space
+        XCTAssertFalse(KeyboardShortcut.canUseWithoutModifiers(keyCode: 53))  // Escape
+    }
+
+    // MARK: - Codable
+
+    func testCodableRoundtrip_preservesAllFields() {
+        let original = KeyboardShortcut(
+            keyCode: 36,
+            modifierFlags: [.command, .shift],
+            characters: "\r",
+            charactersIgnoringModifiers: "r"
+        )
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        guard let data = try? encoder.encode(original),
+              let decoded = try? decoder.decode(KeyboardShortcut.self, from: data) else {
+            XCTFail("Codable roundtrip failed")
+            return
+        }
+
+        XCTAssertEqual(decoded.keyCode, original.keyCode)
+        XCTAssertEqual(decoded.modifierFlags, original.modifierFlags)
+        XCTAssertEqual(decoded.characters, original.characters)
+        XCTAssertEqual(decoded.charactersIgnoringModifiers, original.charactersIgnoringModifiers)
+    }
+
+    func testCodableRoundtrip_modifierOnlyShortcut() {
+        let original = KeyboardShortcut(keyCode: nil, modifierFlags: [.command, .option])
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        guard let data = try? encoder.encode(original),
+              let decoded = try? decoder.decode(KeyboardShortcut.self, from: data) else {
+            XCTFail("Codable roundtrip failed")
+            return
+        }
+
+        XCTAssertNil(decoded.keyCode)
+        XCTAssertEqual(decoded.modifierFlags, [.command, .option])
+        XCTAssertTrue(decoded.isModifierOnly)
+    }
+
+    func testDecodeFromJSON() {
+        let json = """
+        {
+            "keyCode": 36,
+            "modifierFlagsRawValue": 1179648,
+            "characters": "\\r",
+            "charactersIgnoringModifiers": "r"
+        }
+        """
+        let decoder = JSONDecoder()
+        guard let data = json.data(using: .utf8),
+              let shortcut = try? decoder.decode(KeyboardShortcut.self, from: data) else {
+            XCTFail("JSON decoding failed")
+            return
+        }
+
+        XCTAssertEqual(shortcut.keyCode, 36)
+        XCTAssertEqual(shortcut.characters, "\r")
+        XCTAssertEqual(shortcut.charactersIgnoringModifiers, "r")
+        // 1179648 = NSEvent.ModifierFlags([.command, .shift]).rawValue (1048576 + 131072)
+        XCTAssertEqual(shortcut.modifierFlags, [.command, .shift])
+    }
+
+    // MARK: - Equatable
+
+    func testEquatable_sameShortcutsAreEqual() {
+        let a = KeyboardShortcut(keyCode: 36, modifierFlags: [.command], characters: "\r", charactersIgnoringModifiers: "r")
+        let b = KeyboardShortcut(keyCode: 36, modifierFlags: [.command], characters: "\r", charactersIgnoringModifiers: "r")
+        XCTAssertEqual(a, b)
+    }
+
+    func testEquatable_differentModifierFlagsAreNotEqual() {
+        let a = KeyboardShortcut(keyCode: 36, modifierFlags: [.command])
+        let b = KeyboardShortcut(keyCode: 36, modifierFlags: [.option])
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testEquatable_differentKeyCodesAreNotEqual() {
+        let a = KeyboardShortcut(keyCode: 36, modifierFlags: [.command])
+        let b = KeyboardShortcut(keyCode: 0, modifierFlags: [.command])
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: - NSEvent.ModifierFlags extension
+
+    func testSwiftShiftShortcutMask_excludesCapsLock() {
+        XCTAssertFalse(NSEvent.ModifierFlags.swiftShiftShortcutMask.contains(.capsLock))
+    }
+
+    func testSwiftShiftShortcutMask_includesCoreModifiers() {
+        let mask = NSEvent.ModifierFlags.swiftShiftShortcutMask
+        XCTAssertTrue(mask.contains(.command))
+        XCTAssertTrue(mask.contains(.option))
+        XCTAssertTrue(mask.contains(.shift))
+        XCTAssertTrue(mask.contains(.control))
+        XCTAssertTrue(mask.contains(.function))
+    }
+}

--- a/SwiftShiftTests/PreferencesManagerTests.swift
+++ b/SwiftShiftTests/PreferencesManagerTests.swift
@@ -1,0 +1,219 @@
+import XCTest
+@testable import Swift_Shift_Dev
+
+final class PreferencesManagerTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Clear UserDefaults for the test suite to avoid cross-test contamination
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: PreferenceKey.ignoredApps.rawValue)
+        defaults.removeObject(forKey: PreferenceKey.focusOnApp.rawValue)
+        defaults.removeObject(forKey: PreferenceKey.showMenuBarIcon.rawValue)
+        defaults.removeObject(forKey: PreferenceKey.useQuadrants.rawValue)
+        defaults.removeObject(forKey: PreferenceKey.requireMouseClick.rawValue)
+        // Default to migration-complete to prevent tests from accidentally triggering migration
+        defaults.set(true, forKey: PreferenceKey.didMigrateDefaultIgnoredApps.rawValue)
+        defaults.synchronize()
+        PreferencesManager.invalidateIgnoredAppsCache()
+    }
+
+    override func tearDown() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: PreferenceKey.ignoredApps.rawValue)
+        defaults.removeObject(forKey: PreferenceKey.didMigrateDefaultIgnoredApps.rawValue)
+        defaults.removeObject(forKey: PreferenceKey.focusOnApp.rawValue)
+        defaults.removeObject(forKey: PreferenceKey.showMenuBarIcon.rawValue)
+        defaults.removeObject(forKey: PreferenceKey.useQuadrants.rawValue)
+        defaults.removeObject(forKey: PreferenceKey.requireMouseClick.rawValue)
+        defaults.synchronize()
+        PreferencesManager.invalidateIgnoredAppsCache()
+        super.tearDown()
+    }
+
+    // MARK: - Bool Preferences
+
+    func testLoadBool_defaultValue() {
+        // UserDefaults returns false for unset keys
+        XCTAssertFalse(PreferencesManager.loadBool(for: .useQuadrants))
+    }
+
+    func testLoadBool_setAndRead() {
+        UserDefaults.standard.set(true, forKey: PreferenceKey.focusOnApp.rawValue)
+        XCTAssertTrue(PreferencesManager.loadBool(for: .focusOnApp))
+
+        UserDefaults.standard.set(false, forKey: PreferenceKey.focusOnApp.rawValue)
+        XCTAssertFalse(PreferencesManager.loadBool(for: .focusOnApp))
+    }
+
+    // MARK: - Ignored Apps
+
+    func testGetIgnoredApps_includesSystemApps() {
+        let apps = PreferencesManager.getIgnoredApps()
+        // System ignored apps are always present
+        XCTAssertTrue(apps.contains("com.apple.notificationcenterui"))
+    }
+
+    func testGetIgnoredApps_includesDefaultsOnFirstLaunch() {
+        // Simulate first launch: clear migration flag and saved apps
+        UserDefaults.standard.removeObject(forKey: PreferenceKey.didMigrateDefaultIgnoredApps.rawValue)
+        UserDefaults.standard.removeObject(forKey: PreferenceKey.ignoredApps.rawValue)
+        PreferencesManager.invalidateIgnoredAppsCache()
+        
+        let apps = PreferencesManager.getIgnoredApps()
+
+        // Should contain at least the system apps + defaults
+        XCTAssertTrue(apps.contains("com.apple.notificationcenterui"))
+        // At least one of the default apps should be present
+        let hasDefaultApp = apps.contains { DEFAULT_IGNORED_APP_BUNDLE_ID.contains($0) }
+        XCTAssertTrue(hasDefaultApp, "Should include default ignored apps on first launch")
+    }
+
+    func testGetUserIgnoredApps_whenEmpty_returnsDefaults() {
+        // Simulate first launch: clear migration flag and saved apps
+        UserDefaults.standard.removeObject(forKey: PreferenceKey.didMigrateDefaultIgnoredApps.rawValue)
+        UserDefaults.standard.removeObject(forKey: PreferenceKey.ignoredApps.rawValue)
+        PreferencesManager.invalidateIgnoredAppsCache()
+        
+        let apps = PreferencesManager.getUserIgnoredApps()
+        XCTAssertFalse(apps.isEmpty)
+        // All returned apps should be from the default list
+        for app in apps {
+            XCTAssertTrue(DEFAULT_IGNORED_APP_BUNDLE_ID.contains(app),
+                          "\(app) should be in DEFAULT_IGNORED_APP_BUNDLE_ID")
+        }
+    }
+
+    func testSetUserIgnoredApps_overridesList() {
+        // Mark migration as done to prevent defaults from being merged
+        UserDefaults.standard.set(true, forKey: PreferenceKey.didMigrateDefaultIgnoredApps.rawValue)
+        PreferencesManager.invalidateIgnoredAppsCache()
+        
+        let customApps = ["com.example.app1", "com.example.app2"]
+        PreferencesManager.setUserIgnoredApps(customApps)
+
+        let retrieved = PreferencesManager.getUserIgnoredApps()
+        XCTAssertEqual(Set(retrieved), Set(customApps))
+    }
+
+    func testAddIgnoredApp_addsToExistingList() {
+        // Start with a known list
+        PreferencesManager.setUserIgnoredApps(["com.example.existing"])
+        PreferencesManager.addIgnoredApp("com.example.newapp")
+
+        let apps = PreferencesManager.getUserIgnoredApps()
+        XCTAssertTrue(apps.contains("com.example.existing"))
+        XCTAssertTrue(apps.contains("com.example.newapp"))
+    }
+
+    func testAddIgnoredApp_doesNotAddDuplicates() {
+        PreferencesManager.setUserIgnoredApps(["com.example.app"])
+        PreferencesManager.addIgnoredApp("com.example.app")
+        PreferencesManager.addIgnoredApp("com.example.app")
+
+        let apps = PreferencesManager.getUserIgnoredApps()
+        XCTAssertEqual(apps.filter { $0 == "com.example.app" }.count, 1)
+    }
+
+    func testAddIgnoredApp_preventsSystemAppAddition() {
+        // System ignored apps cannot be added to the user list
+        PreferencesManager.setUserIgnoredApps(["com.example.app"])
+        PreferencesManager.addIgnoredApp("com.apple.notificationcenterui")
+
+        let apps = PreferencesManager.getUserIgnoredApps()
+        XCTAssertFalse(apps.contains("com.apple.notificationcenterui"))
+    }
+
+    func testRemoveIgnoredApp_removesFromList() {
+        PreferencesManager.setUserIgnoredApps(["com.example.app1", "com.example.app2"])
+        PreferencesManager.removeIgnoredApp("com.example.app1")
+
+        let apps = PreferencesManager.getUserIgnoredApps()
+        XCTAssertFalse(apps.contains("com.example.app1"))
+        XCTAssertTrue(apps.contains("com.example.app2"))
+    }
+
+    func testRemoveIgnoredApp_cannotRemoveSystemApp() {
+        // Even if a system app somehow ends up in the user list, removal is blocked
+        PreferencesManager.setUserIgnoredApps(["com.apple.notificationcenterui", "com.example.app"])
+        PreferencesManager.removeIgnoredApp("com.apple.notificationcenterui")
+
+        let apps = PreferencesManager.getUserIgnoredApps()
+        // The system app remains in the user list because the guard prevents removal
+        XCTAssertTrue(apps.contains("com.apple.notificationcenterui"))
+        XCTAssertTrue(apps.contains("com.example.app"))
+    }
+
+    func testIsAppIgnored_checksBothLists() {
+        // Reset to first-launch state to include default apps
+        UserDefaults.standard.removeObject(forKey: PreferenceKey.didMigrateDefaultIgnoredApps.rawValue)
+        UserDefaults.standard.removeObject(forKey: PreferenceKey.ignoredApps.rawValue)
+        PreferencesManager.invalidateIgnoredAppsCache()
+        
+        // System apps are always ignored
+        XCTAssertTrue(PreferencesManager.isAppIgnored("com.apple.notificationcenterui"))
+
+        // Default apps are initially ignored
+        XCTAssertTrue(PreferencesManager.isAppIgnored("pl.maketheweb.cleanshotx"))
+    }
+
+    func testIsAppIgnored_respectsCustomList() {
+        PreferencesManager.setUserIgnoredApps(["com.example.custom"])
+        XCTAssertTrue(PreferencesManager.isAppIgnored("com.example.custom"))
+        XCTAssertFalse(PreferencesManager.isAppIgnored("com.other.app"))
+    }
+
+    // MARK: - Cache Invalidation
+
+    func testCacheInvalidation_reflectsChanges() {
+        // Populate cache
+        let _ = PreferencesManager.getIgnoredApps()
+
+        // Change user list
+        PreferencesManager.setUserIgnoredApps(["com.example.cachedtest"])
+        PreferencesManager.invalidateIgnoredAppsCache()
+
+        // Should reflect the new list
+        let apps = PreferencesManager.getIgnoredApps()
+        XCTAssertTrue(apps.contains("com.example.cachedtest"))
+    }
+
+    func testAddIgnoredApp_invalidatesCache() {
+        PreferencesManager.setUserIgnoredApps(["com.example.initial"])
+        let _ = PreferencesManager.getIgnoredApps() // populate cache
+
+        PreferencesManager.addIgnoredApp("com.example.added")
+        let apps = PreferencesManager.getIgnoredApps()
+        XCTAssertTrue(apps.contains("com.example.added"))
+    }
+
+    // MARK: - Migration
+
+    func testMigration_addsDefaultAppsWhenMissing() {
+        // Reset migration flag
+        UserDefaults.standard.removeObject(forKey: PreferenceKey.didMigrateDefaultIgnoredApps.rawValue)
+        PreferencesManager.invalidateIgnoredAppsCache()
+
+        // Set a custom list without defaults
+        PreferencesManager.setUserIgnoredApps(["com.example.only"])
+
+        // First call to getUserIgnoredApps should trigger migration
+        let apps = PreferencesManager.getUserIgnoredApps()
+        XCTAssertTrue(apps.contains("com.example.only"))
+
+        // After migration, the migration flag should be set
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: PreferenceKey.didMigrateDefaultIgnoredApps.rawValue))
+    }
+
+    func testMigration_doesNotRunTwice() {
+        // Mark migration as done
+        UserDefaults.standard.set(true, forKey: PreferenceKey.didMigrateDefaultIgnoredApps.rawValue)
+
+        let customApps = ["com.example.unique"]
+        PreferencesManager.setUserIgnoredApps(customApps)
+
+        let apps = PreferencesManager.getUserIgnoredApps()
+        // Should only return the custom apps, not merged with defaults
+        XCTAssertEqual(Set(apps), Set(customApps))
+    }
+}

--- a/SwiftShiftTests/WindowManagerTests.swift
+++ b/SwiftShiftTests/WindowManagerTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import Swift_Shift_Dev
+
+final class WindowManagerTests: XCTestCase {
+
+    // MARK: - Coordinate Conversion
+
+    func testConvertYCoordinate_flipsYAxis() {
+        // In AppKit, y=0 is at bottom; in CoreGraphics, y=0 is at top
+        // convertYCoordinateBecauseTheAreTwoFuckingCoordinateSystems flips relative to main display height
+        let mainDisplayHeight = CGDisplayBounds(CGMainDisplayID()).height
+        let point = NSPoint(x: 100, y: 200)
+
+        let converted = WindowManager.convertYCoordinateBecauseTheAreTwoFuckingCoordinateSystems(point: point)
+
+        XCTAssertEqual(converted.x, 100)
+        XCTAssertEqual(converted.y, mainDisplayHeight - 200)
+    }
+
+    func testConvertYCoordinate_doubleConversionIsIdentity() {
+        let original = NSPoint(x: 500, y: 300)
+        let convertedOnce = WindowManager.convertYCoordinateBecauseTheAreTwoFuckingCoordinateSystems(point: original)
+        let convertedTwice = WindowManager.convertYCoordinateBecauseTheAreTwoFuckingCoordinateSystems(point: convertedOnce)
+
+        XCTAssertEqual(convertedTwice.x, original.x, accuracy: 0.01)
+        XCTAssertEqual(convertedTwice.y, original.y, accuracy: 0.01)
+    }
+
+    func testConvertYCoordinate_atOrigin() {
+        let converted = WindowManager.convertYCoordinateBecauseTheAreTwoFuckingCoordinateSystems(point: NSPoint(x: 0, y: 0))
+        let mainDisplayHeight = CGDisplayBounds(CGMainDisplayID()).height
+
+        XCTAssertEqual(converted.x, 0)
+        XCTAssertEqual(converted.y, mainDisplayHeight)
+    }
+
+    // MARK: - Window Bounds
+
+    func testGetWindowBounds_producesCorrectCorners() {
+        let location = NSPoint(x: 100, y: 200)
+        let size = CGSize(width: 300, height: 400)
+        let displayHeight = CGDisplayBounds(CGMainDisplayID()).height
+
+        let bounds = WindowManager.getWindowBounds(windowLocation: location, windowSize: size)
+
+        // The function converts the Y coordinate: y' = displayHeight - y
+        let expectedY = displayHeight - location.y
+
+        // topLeft: the point itself after conversion
+        XCTAssertEqual(bounds.topLeft.x, location.x, accuracy: 0.01)
+        XCTAssertEqual(bounds.topLeft.y, expectedY, accuracy: 0.01)
+
+        // topRight: x + width
+        XCTAssertEqual(bounds.topRight.x, location.x + size.width, accuracy: 0.01)
+        XCTAssertEqual(bounds.topRight.y, expectedY, accuracy: 0.01)
+
+        // bottomLeft: x, y - height
+        XCTAssertEqual(bounds.bottomLeft.x, location.x, accuracy: 0.01)
+        XCTAssertEqual(bounds.bottomLeft.y, expectedY - size.height, accuracy: 0.01)
+
+        // bottomRight: x + width, y - height
+        XCTAssertEqual(bounds.bottomRight.x, location.x + size.width, accuracy: 0.01)
+        XCTAssertEqual(bounds.bottomRight.y, expectedY - size.height, accuracy: 0.01)
+    }
+
+    func testGetWindowBounds_withZeroSize() {
+        let location = NSPoint(x: 0, y: 0)
+        let size = CGSize(width: 0, height: 0)
+
+        let bounds = WindowManager.getWindowBounds(windowLocation: location, windowSize: size)
+        let displayHeight = CGDisplayBounds(CGMainDisplayID()).height
+
+        // All corners should be at the same point (top-left after conversion)
+        XCTAssertEqual(bounds.topLeft.x, 0, accuracy: 0.01)
+        XCTAssertEqual(bounds.topLeft.y, displayHeight, accuracy: 0.01)
+        XCTAssertEqual(bounds.topRight.x, 0, accuracy: 0.01)
+        XCTAssertEqual(bounds.topRight.y, displayHeight, accuracy: 0.01)
+        XCTAssertEqual(bounds.bottomLeft.x, 0, accuracy: 0.01)
+        XCTAssertEqual(bounds.bottomLeft.y, displayHeight, accuracy: 0.01)
+        XCTAssertEqual(bounds.bottomRight.x, 0, accuracy: 0.01)
+        XCTAssertEqual(bounds.bottomRight.y, displayHeight, accuracy: 0.01)
+    }
+
+    // MARK: - Window Bounds Structure
+
+    func testWindowBounds_isFullyDefined() {
+        let bounds = WindowBounds(
+            topLeft: NSPoint(x: 0, y: 100),
+            topRight: NSPoint(x: 100, y: 100),
+            bottomLeft: NSPoint(x: 0, y: 0),
+            bottomRight: NSPoint(x: 100, y: 0)
+        )
+
+        XCTAssertEqual(bounds.topLeft.x, 0)
+        XCTAssertEqual(bounds.topLeft.y, 100)
+        XCTAssertEqual(bounds.topRight.x, 100)
+        XCTAssertEqual(bounds.bottomRight.y, 0)
+    }
+}


### PR DESCRIPTION
Closes #173

## What
Adds the project's first test target with 49 unit tests covering the three most testable modules.

## Test suites
- **KeyboardShortcutTests** (26) — encoding/decoding, display strings, modifier flags, equatable, JSON roundtrip
- **PreferencesManagerTests** (17) — ignored app CRUD, caching, migration, system app protection
- **WindowManagerTests** (6) — coordinate conversion, window bounds calculation

## Changes
- New `SwiftShiftTests` unit test bundle with `@testable import Swift_Shift_Dev`
- `make test` target added to Makefile
- CI workflow updated with parallel `test` job on PRs and main pushes
- Scheme updated with code coverage disabled (avoids SPM linking issue)

## Not in scope
- `MouseTracker`, `ShortcutsManager`, `CGEventSupervisor` — tightly coupled to system event taps/AXUIElement, need refactoring for testability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to include automated testing.
  * Added test infrastructure and build configurations to project.

* **Tests**
  * Introduced comprehensive test suites for keyboard shortcuts, preferences, and window management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->