### PR TITLE
Fix #173 followup: address CodeRabbit review items

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build & Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths-ignore:
@@ -15,13 +18,17 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
       - run: make build
 
   test:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
       - name: Build and run tests
         run: |
           xcodebuild test \

--- a/.github/workflows/www.yml
+++ b/.github/workflows/www.yml
@@ -1,5 +1,8 @@
 name: Website
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -18,10 +21,12 @@ jobs:
       run:
         working-directory: www
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
       - run: bun install
       - run: bun run build

--- a/Swift Shift.xcodeproj/project.pbxproj
+++ b/Swift Shift.xcodeproj/project.pbxproj
@@ -91,7 +91,7 @@
 		E2D8CFB82B3C3B9B00EBB047 /* PermissionsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsManager.swift; sourceTree = "<group>"; };
 		E2E6F5E92B3EF03C005B0D96 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		F400D7AF72C65A047C5C9D19 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = "Swift Shift/src/Constants.swift"; sourceTree = "<group>"; };
-		F8B92CDB5F568BDAA9756F45 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		F8B92CDB5F568BDAA9756F45 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -602,7 +602,7 @@
 					"$(inherited)",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pablopunk.SwiftShiftTests;
 				PRODUCT_NAME = SwiftShiftTests;
 				SWIFT_VERSION = 5.0;
@@ -620,7 +620,7 @@
 					"$(inherited)",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pablopunk.SwiftShiftTests;
 				PRODUCT_NAME = SwiftShiftTests;
 				SWIFT_VERSION = 5.0;

--- a/Swift Shift.xcodeproj/xcshareddata/xcschemes/Swift Shift.xcscheme
+++ b/Swift Shift.xcodeproj/xcshareddata/xcschemes/Swift Shift.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D76A70D72EB4AAB358AE0D75"
+               BlueprintIdentifier = "4F0E66367D37633ED8A08262"
                BuildableName = "SwiftShiftTests.xctest"
                BlueprintName = "SwiftShiftTests"
                ReferencedContainer = "container:Swift Shift.xcodeproj">
@@ -48,7 +48,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D76A70D72EB4AAB358AE0D75"
+               BlueprintIdentifier = "4F0E66367D37633ED8A08262"
                BuildableName = "SwiftShiftTests.xctest"
                BlueprintName = "SwiftShiftTests"
                ReferencedContainer = "container:Swift Shift.xcodeproj">

--- a/SwiftShiftTests/PreferencesManagerTests.swift
+++ b/SwiftShiftTests/PreferencesManagerTests.swift
@@ -153,8 +153,10 @@ final class PreferencesManagerTests: XCTestCase {
         // System apps are always ignored
         XCTAssertTrue(PreferencesManager.isAppIgnored("com.apple.notificationcenterui"))
 
-        // Default apps are initially ignored
-        XCTAssertTrue(PreferencesManager.isAppIgnored("pl.maketheweb.cleanshotx"))
+        // At least one default app should be initially ignored
+        XCTAssertTrue(
+            DEFAULT_IGNORED_APP_BUNDLE_ID.contains { PreferencesManager.isAppIgnored($0) }
+        )
     }
 
     func testIsAppIgnored_respectsCustomList() {


### PR DESCRIPTION
Addresses review comments from #174 merge:

- **BlueprintIdentifier mismatch**: scheme referenced stale target ID `D76A70D7` instead of actual `4F0E6636`
- **Deployment target**: lowered from 14.0 → 13.0 to match app target
- **Foundation.framework path**: replaced hardcoded SDK version path with SDKROOT-relative
- **Test hardening**: use `DEFAULT_IGNORED_APP_BUNDLE_ID` constant instead of hardcoded bundle ID

All 49 tests pass after changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow security with explicit permissions and pinned action versions.
  * Lowered minimum macOS deployment target, extending app compatibility to older systems.

* **Tests**
  * Improved test suite assertions for more robust validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->