### PR TITLE
fix: smooth move/resize on Chromium/Electron apps by disabling AXEnhancedUserInterface during the gesture

### DIFF
--- a/Swift Shift/src/Manager/MouseTracker.swift
+++ b/Swift Shift/src/Manager/MouseTracker.swift
@@ -18,6 +18,8 @@ class MouseTracker {
     private let trackingQueue = DispatchQueue(label: "com.swiftshift.mousetracker")
     private var queuedExternalMouseUpdate: (location: NSPoint, timestamp: TimeInterval)?
     private var queuedExternalMouseUpdateScheduled = false
+    private var enhancedUIApp: AXUIElement?
+    private var enhancedUIPrev: Bool?
     private init() { registerForSpaceChangeNotifications() }
     deinit { unregisterForSpaceChangeNotifications() }
     private func registerForSpaceChangeNotifications() {
@@ -46,7 +48,33 @@ class MouseTracker {
     }
     func stopTracking(for action: MouseAction) {
         guard currentAction == action else { return }
+        restoreEnhancedUIForTrackedApp()
         flushQueuedExternalMouseUpdate(); flushPendingMouseUpdate(); invalidateTrackingTimer(); removeMouseEventMonitor(); resetTrackingVariables(); clearQueuedExternalMouseUpdate(); isTracking = false
+    }
+    // Chromium/Electron apps turn on AXEnhancedUserInterface while an AX client is
+    // active, which makes AX position/size changes slow and non-live (laggy drag/resize), even
+    // though native title-bar drag / corner-resize of the same window is smooth. Disable it for
+    // the tracked app during the gesture and restore it on mouse-up. Public AX API, no SIP.
+    private static let enhancedUIAttribute = "AXEnhancedUserInterface" as CFString
+    private func disableEnhancedUIForTrackedApp() {
+        guard let window = trackedWindow else { return }
+        var pid: pid_t = 0
+        guard AXUIElementGetPid(window, &pid) == .success, pid > 0 else { return }
+        let app = AXUIElementCreateApplication(pid)
+        var value: CFTypeRef?
+        let readOK = AXUIElementCopyAttributeValue(app, MouseTracker.enhancedUIAttribute, &value) == .success
+        var wasOn = false
+        if readOK, let v = value, CFGetTypeID(v) == CFBooleanGetTypeID() { wasOn = CFBooleanGetValue((v as! CFBoolean)) }
+        enhancedUIApp = app
+        enhancedUIPrev = readOK ? wasOn : nil
+        if wasOn { AXUIElementSetAttributeValue(app, MouseTracker.enhancedUIAttribute, kCFBooleanFalse) }
+    }
+    private func restoreEnhancedUIForTrackedApp() {
+        if let app = enhancedUIApp, enhancedUIPrev == true {
+            AXUIElementSetAttributeValue(app, MouseTracker.enhancedUIAttribute, kCFBooleanTrue)
+        }
+        enhancedUIApp = nil
+        enhancedUIPrev = nil
     }
     func forceResetTracking() {
         guard currentAction != .none, let window = trackedWindow else { return }
@@ -74,6 +102,7 @@ class MouseTracker {
         if action == .resize && shouldUseQuadrants, let m = initialMouseLocation, let w = initialWindowLocation, let s = windowSize {
             quadrant = determineQuadrant(mouseLocation: windowBoundsMouseLocation(m), windowSize: s, windowLocation: w)
         }
+        disableEnhancedUIForTrackedApp()
     }
     private func shouldIgnore(window: AXUIElement) -> Bool {
         guard let app = WindowManager.getNSApplication(from: window), let bid = app.bundleIdentifier, PreferencesManager.isAppIgnored(bid) else { return false }

--- a/Swift Shift/src/Manager/MouseTracker.swift
+++ b/Swift Shift/src/Manager/MouseTracker.swift
@@ -48,14 +48,19 @@ class MouseTracker {
     }
     func stopTracking(for action: MouseAction) {
         guard currentAction == action else { return }
+        // Apply the final pending move/resize while Enhanced UI is still disabled (fast path),
+        // then restore the attribute, then run the remaining cleanup.
+        flushQueuedExternalMouseUpdate(); flushPendingMouseUpdate()
         restoreEnhancedUIForTrackedApp()
-        flushQueuedExternalMouseUpdate(); flushPendingMouseUpdate(); invalidateTrackingTimer(); removeMouseEventMonitor(); resetTrackingVariables(); clearQueuedExternalMouseUpdate(); isTracking = false
+        invalidateTrackingTimer(); removeMouseEventMonitor(); resetTrackingVariables(); clearQueuedExternalMouseUpdate(); isTracking = false
     }
-    // Chromium/Electron apps turn on AXEnhancedUserInterface while an AX client is
-    // active, which makes AX position/size changes slow and non-live (laggy drag/resize), even
-    // though native title-bar drag / corner-resize of the same window is smooth. Disable it for
-    // the tracked app during the gesture and restore it on mouse-up. Public AX API, no SIP.
     private static let enhancedUIAttribute = "AXEnhancedUserInterface" as CFString
+    /// Disables `AXEnhancedUserInterface` on the tracked window's app for the duration of a
+    /// move/resize gesture, remembering the previous value so it can be restored on mouse-up.
+    /// Chromium/Electron apps enable this attribute while an AX client is active, which makes
+    /// AX `kAXPosition`/`kAXSize` updates slow and non-live (laggy drag/resize) even though native
+    /// title-bar drag / corner-resize of the same window stays smooth. Apps that don't set the
+    /// attribute (most native AppKit apps) are unaffected. Public AX API, no SIP.
     private func disableEnhancedUIForTrackedApp() {
         guard let window = trackedWindow else { return }
         var pid: pid_t = 0
@@ -69,6 +74,8 @@ class MouseTracker {
         enhancedUIPrev = readOK ? wasOn : nil
         if wasOn { AXUIElementSetAttributeValue(app, MouseTracker.enhancedUIAttribute, kCFBooleanFalse) }
     }
+    /// Restores the tracked app's `AXEnhancedUserInterface` to the value captured when the gesture
+    /// began (only when it was originally enabled) and clears the saved reference.
     private func restoreEnhancedUIForTrackedApp() {
         if let app = enhancedUIApp, enhancedUIPrev == true {
             AXUIElementSetAttributeValue(app, MouseTracker.enhancedUIAttribute, kCFBooleanTrue)


### PR DESCRIPTION
## Problem
On macOS Tahoe (26.x), moving/resizing Chromium/Electron windows (Chrome, VS Code, Obsidian, …) with Swift Shift is laggy and "smeared", while it stays perfectly smooth on native AppKit apps (Finder, Terminal, Sublime, Notes). Crucially, dragging the *same* Electron window by its native title bar, or resizing it by its native corner, is smooth — so the renderer can relayout in real time; the lag is specific to the AX-driven path. Related: #157, #106, #167.

## Root cause
Chromium/Electron apps enable `AXEnhancedUserInterface` on their application element while an AX client is active. With it on, programmatic `AXUIElementSetAttributeValue` updates of `kAXPosition` / `kAXSize` become slow and non-live — which is exactly what Swift Shift does on every mouse move. (Lowering the 120 Hz `minimumUpdateInterval` in `MouseTracker` only helps marginally, confirming it's the per-call cost, not the update rate.)

## Fix
Temporarily disable `AXEnhancedUserInterface` on the tracked window's application for the duration of the gesture, and restore the previous value on mouse-up:
- `prepareTracking` → read & remember the app's current `AXEnhancedUserInterface`, set it to `false` if it was on.
- `stopTracking` → restore the previous value.

Public AX API only, no SIP, no private frameworks. Native apps are unaffected (they don't have the attribute set). Tested on macOS 26.5.1 (Apple Silicon): Chrome / VS Code / Obsidian now move and resize as smoothly as native windows.

## Design note
I restore the attribute on mouse-up to avoid permanently changing the app's accessibility state. The alternative (what yabai does) is to leave it off while the WM is active — simpler, but it alters the app's a11y behaviour globally. Happy to switch, or gate it behind a setting.

## Test plan
- Build Release, grant Accessibility + Input Monitoring.
- Move/resize Chrome, VS Code, Obsidian → smooth (previously laggy).
- Move/resize Finder, Terminal → unchanged.
- Confirm VoiceOver/accessibility still works after a gesture (attribute restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of window move and resize operations by temporarily adjusting accessibility behavior for the tracked app during gestures, then restoring it afterward to minimize disruption and ensure normal functionality resumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->