### PR TITLE
feat: double-tap Move/Resize modifier to maximize / minimize a window

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ There are several ways:
 * Hide menubar icon
 * Focus on window
 * Smart resizing with quadrants
+* Double-tap a modifier key to maximize/restore (Resize key) or minimize (Move key) the window under the cursor
 * Ignore custom apps
 
 ### Quadrants

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are several ways:
 * Hide menubar icon
 * Focus on window
 * Smart resizing with quadrants
-* Double-tap a modifier key to maximize/restore (Resize key) or minimize (Move key) the window under the cursor
+* Double-tap a modifier key to maximize/restore (Resize key) or minimize (Move key) the window under the cursor — the two are swappable
 * Ignore custom apps
 
 ### Quadrants

--- a/Swift Shift/src/AppDelegate.swift
+++ b/Swift Shift/src/AppDelegate.swift
@@ -14,6 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   func applicationDidFinishLaunching(_ notification: Notification) {
     let _ = ShortcutsManager.shared // immediately register shortcuts so we won't wait for the UI
     MouseChordActionManager.shared.updateSubscriptions()
+    DoubleTapActionManager.shared.updateSubscriptions()
   }
   
   func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
@@ -25,5 +26,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     shortcutMonitor?.removeAllActions()
     ShortcutsManager.shared.cleanupAllShortcuts()
     MouseChordActionManager.shared.cleanup()
+    DoubleTapActionManager.shared.cleanup()
   }
 }

--- a/Swift Shift/src/Manager/MouseTracker.swift
+++ b/Swift Shift/src/Manager/MouseTracker.swift
@@ -100,6 +100,10 @@ class MouseTracker {
         }
     }
     private func prepareTracking(for action: MouseAction, mouseLocation: NSPoint, coordinateSpace: MouseLocationCoordinateSpace) {
+        // A double-tap maximize/restore glide shares AXWindowWriter with this
+        // gesture. Cancel it first so an in-flight animation can't keep writing
+        // frames for the wrong window (or detach the writer mid-drag when it finishes).
+        WindowSnapActionRunner.shared.cancelAnimation()
         mouseLocationCoordinateSpace = coordinateSpace
         let currentWindow = coordinateSpace == .coreGraphics ? WindowManager.getCurrentWindow(at: mouseLocation) : WindowManager.getCurrentWindow()
         guard let currentWindow = currentWindow, !shouldIgnore(window: currentWindow) else { trackedWindow = nil; return }

--- a/Swift Shift/src/Manager/Preferences.swift
+++ b/Swift Shift/src/Manager/Preferences.swift
@@ -7,6 +7,7 @@ enum PreferenceKey: String {
     case snapToWindows = "snapToWindows"
     case requireMouseClick = "requireMouseClick"
     case moveWithBothMouseButtons = "moveWithBothMouseButtons"
+    case doubleTapModifierActions = "doubleTapModifierActions"
     case fnShortcutWarningDismissed = "fnShortcutWarningDismissed"
     case ignoredApps = "ignoredApps"
     case didMigrateDefaultIgnoredApps = "didMigrateDefaultIgnoredApps"

--- a/Swift Shift/src/Manager/Preferences.swift
+++ b/Swift Shift/src/Manager/Preferences.swift
@@ -8,6 +8,7 @@ enum PreferenceKey: String {
     case requireMouseClick = "requireMouseClick"
     case moveWithBothMouseButtons = "moveWithBothMouseButtons"
     case doubleTapModifierActions = "doubleTapModifierActions"
+    case doubleTapActionsSwapped = "doubleTapActionsSwapped"
     case fnShortcutWarningDismissed = "fnShortcutWarningDismissed"
     case ignoredApps = "ignoredApps"
     case didMigrateDefaultIgnoredApps = "didMigrateDefaultIgnoredApps"

--- a/Swift Shift/src/Manager/ShortcutsManager.swift
+++ b/Swift Shift/src/Manager/ShortcutsManager.swift
@@ -273,6 +273,7 @@ class ShortcutsManager {
     CGEventSupervisor.shared.cancelAll()
     updateGlobalShortcuts()
     MouseChordActionManager.shared.forceRebuild()
+    DoubleTapActionManager.shared.forceRebuild()
   }
 
   private func handleSpaceChange() {
@@ -330,6 +331,7 @@ class ShortcutsManager {
 
     updateGlobalShortcuts()
     MouseChordActionManager.shared.updateSubscriptions()
+    DoubleTapActionManager.shared.updateSubscriptions()
     NotificationCenter.default.post(name: .shortcutsDidChange, object: userShortcut.type)
   }
 
@@ -380,6 +382,7 @@ class ShortcutsManager {
     UserDefaults.standard.removeObject(forKey: mouseEnabledKey(for: type))
     updateGlobalShortcuts()
     MouseChordActionManager.shared.updateSubscriptions()
+    DoubleTapActionManager.shared.updateSubscriptions()
     NotificationCenter.default.post(name: .shortcutsDidChange, object: type)
   }
 
@@ -1102,5 +1105,253 @@ class MouseChordActionManager {
     }
 
     return nil
+  }
+}
+
+// MARK: - Double-tap modifier actions
+
+enum WindowSnapAction {
+  /// Fill the screen; a second trigger on an already-maximized window restores it.
+  case toggleMaximize
+  /// Minimize the window to the Dock.
+  case minimize
+}
+
+/// Applies `WindowSnapAction`s to the window under the cursor (falling back to the
+/// focused window). Keeps a small history of pre-maximize frames so the maximize
+/// action can toggle back to where the window was.
+final class WindowSnapActionRunner {
+  static let shared = WindowSnapActionRunner()
+  private init() {}
+
+  private struct MaximizedRecord {
+    let window: AXUIElement
+    let restoreFrame: CGRect
+  }
+
+  private var maximizedRecords: [MaximizedRecord] = []
+  private let maxRecords = 12
+  /// Frames within this many points of the screen's visible frame count as "maximized".
+  private let frameTolerance: CGFloat = 4
+
+  func perform(_ action: WindowSnapAction) {
+    guard let window = targetWindow() else {
+      NSSound.beep()
+      return
+    }
+
+    switch action {
+    case .toggleMaximize:
+      toggleMaximize(window)
+    case .minimize:
+      WindowManager.setMinimized(window: window, true)
+    }
+  }
+
+  private func targetWindow() -> AXUIElement? {
+    if let underCursor = WindowManager.getCurrentWindow(), !isIgnored(underCursor) {
+      return underCursor
+    }
+    return WindowManager.getFocusedWindow()
+  }
+
+  private func isIgnored(_ window: AXUIElement) -> Bool {
+    guard let app = WindowManager.getNSApplication(from: window), let bundleId = app.bundleIdentifier else { return false }
+    return PreferencesManager.isAppIgnored(bundleId)
+  }
+
+  private func toggleMaximize(_ window: AXUIElement) {
+    guard let current = WindowManager.getFrame(window: window),
+          let visibleFrame = WindowManager.screenAXVisibleFrame(containing: current) else { return }
+
+    maximizedRecords.removeAll { !WindowManager.isAlive(window: $0.window) }
+    let recordIndex = maximizedRecords.firstIndex { CFEqual($0.window, window) }
+    let isMaximized = rectsApproximatelyEqual(current, visibleFrame, tolerance: frameTolerance)
+
+    if isMaximized, let recordIndex {
+      let restoreFrame = maximizedRecords.remove(at: recordIndex).restoreFrame
+      WindowManager.setFrame(window: window, to: restoreFrame)
+    } else if isMaximized {
+      // Maximized by some other means and we have nothing to restore to —
+      // fall back to a centered window at 60% of the visible frame.
+      let size = CGSize(width: visibleFrame.width * 0.6, height: visibleFrame.height * 0.6)
+      let origin = CGPoint(x: visibleFrame.midX - size.width / 2, y: visibleFrame.midY - size.height / 2)
+      WindowManager.setFrame(window: window, to: CGRect(origin: origin, size: size))
+    } else {
+      if let recordIndex { maximizedRecords.remove(at: recordIndex) }
+      maximizedRecords.append(MaximizedRecord(window: window, restoreFrame: current))
+      if maximizedRecords.count > maxRecords {
+        maximizedRecords.removeFirst(maximizedRecords.count - maxRecords)
+      }
+      WindowManager.setFrame(window: window, to: visibleFrame)
+    }
+  }
+
+  private func rectsApproximatelyEqual(_ a: CGRect, _ b: CGRect, tolerance: CGFloat) -> Bool {
+    abs(a.origin.x - b.origin.x) <= tolerance &&
+    abs(a.origin.y - b.origin.y) <= tolerance &&
+    abs(a.width - b.width) <= tolerance &&
+    abs(a.height - b.height) <= tolerance
+  }
+}
+
+/// Detects a quick double-tap of a modifier-only Move/Resize shortcut and runs the
+/// matching `WindowSnapAction`. A single press-hold (the normal drag gesture) never
+/// looks like a double-tap: both taps must be short and close together, with no
+/// other key, no mouse button, and no active drag in between.
+final class DoubleTapActionManager {
+  static let shared = DoubleTapActionManager()
+  private init() {}
+
+  private struct Config {
+    let type: ShortcutType
+    let flags: NSEvent.ModifierFlags
+    let action: WindowSnapAction
+  }
+
+  private struct TapState {
+    var firstPressAt: TimeInterval?
+    var firstReleaseAt: TimeInterval?
+    var secondPressAt: TimeInterval?
+  }
+
+  private var monitors: [Any] = []
+  private var configs: [Config] = []
+  private var tapStates: [ShortcutType: TapState] = [:]
+  private var lastMatched: [ShortcutType: Bool] = [:]
+
+  /// Each tap must be shorter than this, and the gap between them smaller still —
+  /// values a deliberate double-tap clears easily but a hold never does.
+  private let maxTapDuration: TimeInterval = 0.25
+  private let maxGapBetweenTaps: TimeInterval = 0.30
+
+  func updateSubscriptions() {
+    teardown()
+
+    guard PreferencesManager.loadBool(for: .doubleTapModifierActions) else { return }
+    configs = Self.loadConfigs()
+    guard !configs.isEmpty else { return }
+
+    let mask: NSEvent.EventTypeMask = [.flagsChanged, .keyDown, .leftMouseDown, .rightMouseDown]
+    let handler: (NSEvent) -> Void = { [weak self] event in self?.handle(event) }
+
+    if let monitor = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: handler) {
+      monitors.append(monitor)
+    }
+    if let monitor = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { event in
+      handler(event)
+      return event
+    }) {
+      monitors.append(monitor)
+    }
+  }
+
+  /// Full teardown + rebuild, for use after system events that can kill input hooks.
+  func forceRebuild() {
+    updateSubscriptions()
+  }
+
+  func cleanup() {
+    teardown()
+  }
+
+  private func teardown() {
+    for monitor in monitors { NSEvent.removeMonitor(monitor) }
+    monitors.removeAll()
+    tapStates.removeAll()
+    lastMatched.removeAll()
+    configs.removeAll()
+  }
+
+  private static func loadConfigs() -> [Config] {
+    var result: [Config] = []
+    for type in ShortcutType.allCases {
+      guard let userShortcut = ShortcutsManager.shared.load(for: type),
+            userShortcut.keyboardEnabled,
+            let keyboardShortcut = userShortcut.keyboardShortcut,
+            keyboardShortcut.isModifierOnly else { continue }
+
+      let flags = keyboardShortcut.modifierFlags
+      guard !flags.isEmpty else { continue }
+
+      result.append(Config(type: type, flags: flags, action: type == .resize ? .toggleMaximize : .minimize))
+    }
+    return result
+  }
+
+  private func handle(_ event: NSEvent) {
+    switch event.type {
+    case .flagsChanged:
+      handleFlagsChanged(event)
+    case .keyDown, .leftMouseDown, .rightMouseDown:
+      // A real keystroke or click means this isn't a bare double-tap.
+      tapStates.removeAll()
+    default:
+      break
+    }
+  }
+
+  private func handleFlagsChanged(_ event: NSEvent) {
+    let now = event.timestamp
+    let currentFlags = event.modifierFlags.swiftShiftShortcutFlags
+
+    for config in configs {
+      let matched = currentFlags == config.flags
+      let previouslyMatched = lastMatched[config.type] ?? false
+      lastMatched[config.type] = matched
+
+      if matched && !previouslyMatched {
+        handlePress(config, now: now)
+      } else if !matched && previouslyMatched {
+        handleRelease(config, now: now)
+      }
+    }
+  }
+
+  private func handlePress(_ config: Config, now: TimeInterval) {
+    // A held mouse button or an in-progress SwiftShift drag means this modifier
+    // press is the start of a gesture, not a tap.
+    guard NSEvent.pressedMouseButtons == 0, !ShortcutsManager.shared.hasActiveShortcut else {
+      tapStates[config.type] = nil
+      return
+    }
+
+    let state = tapStates[config.type]
+    if let firstPress = state?.firstPressAt,
+       let firstRelease = state?.firstReleaseAt,
+       (firstRelease - firstPress) <= maxTapDuration,
+       (now - firstRelease) <= maxGapBetweenTaps {
+      var updated = state ?? TapState()
+      updated.secondPressAt = now
+      tapStates[config.type] = updated
+    } else {
+      tapStates[config.type] = TapState(firstPressAt: now, firstReleaseAt: nil, secondPressAt: nil)
+    }
+  }
+
+  private func handleRelease(_ config: Config, now: TimeInterval) {
+    guard var state = tapStates[config.type] else { return }
+
+    if let secondPress = state.secondPressAt {
+      tapStates[config.type] = nil
+      guard (now - secondPress) <= maxTapDuration else { return }
+      guard NSEvent.pressedMouseButtons == 0, !ShortcutsManager.shared.hasActiveShortcut else { return }
+      fire(config.action)
+    } else if let firstPress = state.firstPressAt, state.firstReleaseAt == nil {
+      if (now - firstPress) <= maxTapDuration {
+        state.firstReleaseAt = now
+        tapStates[config.type] = state
+      } else {
+        tapStates[config.type] = nil
+      }
+    } else {
+      tapStates[config.type] = nil
+    }
+  }
+
+  private func fire(_ action: WindowSnapAction) {
+    DispatchQueue.main.async {
+      WindowSnapActionRunner.shared.perform(action)
+    }
   }
 }

--- a/Swift Shift/src/Manager/ShortcutsManager.swift
+++ b/Swift Shift/src/Manager/ShortcutsManager.swift
@@ -1133,6 +1133,9 @@ final class WindowSnapActionRunner {
   private let maxRecords = 12
   /// Frames within this many points of the screen's visible frame count as "maximized".
   private let frameTolerance: CGFloat = 4
+  /// How long the maximize / restore glide takes.
+  private let animationDuration: TimeInterval = 0.18
+  private var animator: WindowFrameAnimator?
 
   func perform(_ action: WindowSnapAction) {
     guard let window = targetWindow() else {
@@ -1161,8 +1164,12 @@ final class WindowSnapActionRunner {
   }
 
   private func toggleMaximize(_ window: AXUIElement) {
-    guard let current = WindowManager.getFrame(window: window),
-          let visibleFrame = WindowManager.screenAXVisibleFrame(containing: current) else { return }
+    guard let liveFrame = WindowManager.getFrame(window: window),
+          let visibleFrame = WindowManager.screenAXVisibleFrame(containing: liveFrame) else { return }
+
+    // If a glide for this window is still running, reason about its destination
+    // rather than the half-way frame the window is currently at.
+    let current = (animator.flatMap { CFEqual($0.window, window) ? $0.targetFrame : nil }) ?? liveFrame
 
     maximizedRecords.removeAll { !WindowManager.isAlive(window: $0.window) }
     let recordIndex = maximizedRecords.firstIndex { CFEqual($0.window, window) }
@@ -1170,20 +1177,36 @@ final class WindowSnapActionRunner {
 
     if isMaximized, let recordIndex {
       let restoreFrame = maximizedRecords.remove(at: recordIndex).restoreFrame
-      WindowManager.setFrame(window: window, to: restoreFrame)
+      animate(window, from: liveFrame, to: restoreFrame)
     } else if isMaximized {
       // Maximized by some other means and we have nothing to restore to —
       // fall back to a centered window at 60% of the visible frame.
       let size = CGSize(width: visibleFrame.width * 0.6, height: visibleFrame.height * 0.6)
       let origin = CGPoint(x: visibleFrame.midX - size.width / 2, y: visibleFrame.midY - size.height / 2)
-      WindowManager.setFrame(window: window, to: CGRect(origin: origin, size: size))
+      animate(window, from: liveFrame, to: CGRect(origin: origin, size: size))
     } else {
       if let recordIndex { maximizedRecords.remove(at: recordIndex) }
       maximizedRecords.append(MaximizedRecord(window: window, restoreFrame: current))
       if maximizedRecords.count > maxRecords {
         maximizedRecords.removeFirst(maximizedRecords.count - maxRecords)
       }
-      WindowManager.setFrame(window: window, to: visibleFrame)
+      animate(window, from: liveFrame, to: visibleFrame)
+    }
+  }
+
+  private func animate(_ window: AXUIElement, from start: CGRect, to target: CGRect) {
+    animator?.cancel()
+
+    guard !rectsApproximatelyEqual(start, target, tolerance: 1) else {
+      WindowManager.setFrame(window: window, to: target)
+      animator = nil
+      return
+    }
+
+    let animator = WindowFrameAnimator(window: window, from: start, to: target, duration: animationDuration)
+    self.animator = animator
+    animator.start { [weak self] in
+      if self?.animator === animator { self?.animator = nil }
     }
   }
 
@@ -1192,6 +1215,94 @@ final class WindowSnapActionRunner {
     abs(a.origin.y - b.origin.y) <= tolerance &&
     abs(a.width - b.width) <= tolerance &&
     abs(a.height - b.height) <= tolerance
+  }
+}
+
+/// Glides a window from one frame to another over `duration` with an ease-out curve.
+/// AppKit has no API to animate another app's window, so this interpolates frame by
+/// frame and pushes each step through `AXWindowWriter` (background serial queue,
+/// latest-wins), which keeps the main thread from blocking on slow AX IPC.
+final class WindowFrameAnimator {
+  let window: AXUIElement
+  let targetFrame: CGRect
+
+  private let startFrame: CGRect
+  private let duration: TimeInterval
+  private var startedAt: TimeInterval = 0
+  private var timer: Timer?
+  private var onFinish: (() -> Void)?
+  private var enhancedUIApp: AXUIElement?
+  private var enhancedUIWasEnabled = false
+
+  init(window: AXUIElement, from: CGRect, to: CGRect, duration: TimeInterval) {
+    self.window = window
+    self.startFrame = from
+    self.targetFrame = to
+    self.duration = duration
+  }
+
+  func start(onFinish: @escaping () -> Void) {
+    self.onFinish = onFinish
+
+    if let state = WindowManager.enhancedUIState(forAppOf: window) {
+      enhancedUIApp = state.app
+      enhancedUIWasEnabled = state.wasEnabled
+      if state.wasEnabled { WindowManager.setEnhancedUI(false, forApp: state.app) }
+    }
+
+    AXWindowWriter.shared.beginGesture(window: window, origin: startFrame.origin, size: startFrame.size)
+    startedAt = ProcessInfo.processInfo.systemUptime
+
+    let timer = Timer(timeInterval: 1.0 / 90.0, repeats: true) { [weak self] _ in self?.tick() }
+    RunLoop.main.add(timer, forMode: .common)
+    self.timer = timer
+    tick()
+  }
+
+  /// Stops the glide immediately, leaving the window wherever it currently is.
+  func cancel() {
+    guard timer != nil else { return }
+    timer?.invalidate()
+    timer = nil
+    AXWindowWriter.shared.endGesture()
+    restoreEnhancedUI()
+    onFinish = nil
+  }
+
+  private func tick() {
+    let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+    let t = duration > 0 ? min(1, max(0, elapsed / duration)) : 1
+    let eased = CGFloat(1 - pow(1 - t, 3)) // ease-out cubic
+
+    let frame = CGRect(
+      x: startFrame.origin.x + (targetFrame.origin.x - startFrame.origin.x) * eased,
+      y: startFrame.origin.y + (targetFrame.origin.y - startFrame.origin.y) * eased,
+      width: startFrame.width + (targetFrame.width - startFrame.width) * eased,
+      height: startFrame.height + (targetFrame.height - startFrame.height) * eased
+    )
+    AXWindowWriter.shared.requestResize(origin: frame.origin, size: frame.size)
+
+    if t >= 1 { finish() }
+  }
+
+  private func finish() {
+    guard timer != nil else { return }
+    timer?.invalidate()
+    timer = nil
+    AXWindowWriter.shared.requestResize(origin: targetFrame.origin, size: targetFrame.size)
+    AXWindowWriter.shared.endGesture()
+    restoreEnhancedUI()
+    let callback = onFinish
+    onFinish = nil
+    callback?()
+  }
+
+  private func restoreEnhancedUI() {
+    if let app = enhancedUIApp, enhancedUIWasEnabled {
+      WindowManager.setEnhancedUI(true, forApp: app)
+    }
+    enhancedUIApp = nil
+    enhancedUIWasEnabled = false
   }
 }
 

--- a/Swift Shift/src/Manager/ShortcutsManager.swift
+++ b/Swift Shift/src/Manager/ShortcutsManager.swift
@@ -1167,13 +1167,18 @@ final class WindowSnapActionRunner {
     guard let liveFrame = WindowManager.getFrame(window: window),
           let visibleFrame = WindowManager.screenAXVisibleFrame(containing: liveFrame) else { return }
 
+    // Leave the same edge gap macOS uses when its "Tiled windows have margins"
+    // setting is on; go fully edge-to-edge otherwise.
+    let margin = WindowManager.tiledWindowMarginInset()
+    let maximizeTarget = margin > 0 ? visibleFrame.insetBy(dx: margin, dy: margin) : visibleFrame
+
     // If a glide for this window is still running, reason about its destination
     // rather than the half-way frame the window is currently at.
     let current = (animator.flatMap { CFEqual($0.window, window) ? $0.targetFrame : nil }) ?? liveFrame
 
     maximizedRecords.removeAll { !WindowManager.isAlive(window: $0.window) }
     let recordIndex = maximizedRecords.firstIndex { CFEqual($0.window, window) }
-    let isMaximized = rectsApproximatelyEqual(current, visibleFrame, tolerance: frameTolerance)
+    let isMaximized = rectsApproximatelyEqual(current, maximizeTarget, tolerance: frameTolerance)
 
     if isMaximized, let recordIndex {
       let restoreFrame = maximizedRecords.remove(at: recordIndex).restoreFrame
@@ -1190,7 +1195,7 @@ final class WindowSnapActionRunner {
       if maximizedRecords.count > maxRecords {
         maximizedRecords.removeFirst(maximizedRecords.count - maxRecords)
       }
-      animate(window, from: liveFrame, to: visibleFrame)
+      animate(window, from: liveFrame, to: maximizeTarget)
     }
   }
 

--- a/Swift Shift/src/Manager/ShortcutsManager.swift
+++ b/Swift Shift/src/Manager/ShortcutsManager.swift
@@ -1381,6 +1381,10 @@ final class DoubleTapActionManager {
   }
 
   private static func loadConfigs() -> [Config] {
+    // By default the Resize modifier maximizes and the Move modifier minimizes;
+    // the swap preference flips which modifier does which.
+    let maximizeType: ShortcutType = PreferencesManager.loadBool(for: .doubleTapActionsSwapped) ? .move : .resize
+
     var result: [Config] = []
     for type in ShortcutType.allCases {
       guard let userShortcut = ShortcutsManager.shared.load(for: type),
@@ -1391,7 +1395,7 @@ final class DoubleTapActionManager {
       let flags = keyboardShortcut.modifierFlags
       guard !flags.isEmpty else { continue }
 
-      result.append(Config(type: type, flags: flags, action: type == .resize ? .toggleMaximize : .minimize))
+      result.append(Config(type: type, flags: flags, action: type == maximizeType ? .toggleMaximize : .minimize))
     }
     return result
   }

--- a/Swift Shift/src/Manager/ShortcutsManager.swift
+++ b/Swift Shift/src/Manager/ShortcutsManager.swift
@@ -1197,8 +1197,9 @@ final class WindowSnapActionRunner {
 
 /// Detects a quick double-tap of a modifier-only Move/Resize shortcut and runs the
 /// matching `WindowSnapAction`. A single press-hold (the normal drag gesture) never
-/// looks like a double-tap: both taps must be short and close together, with no
-/// other key, no mouse button, and no active drag in between.
+/// looks like a double-tap: both taps must be short (< `maxTapDuration`) and close
+/// together (< `maxGapBetweenTaps`), with no other key pressed, no mouse button
+/// held, and the pointer barely moving between them.
 final class DoubleTapActionManager {
   static let shared = DoubleTapActionManager()
   private init() {}
@@ -1211,6 +1212,7 @@ final class DoubleTapActionManager {
 
   private struct TapState {
     var firstPressAt: TimeInterval?
+    var firstPressLocation: NSPoint?
     var firstReleaseAt: TimeInterval?
     var secondPressAt: TimeInterval?
   }
@@ -1222,8 +1224,12 @@ final class DoubleTapActionManager {
 
   /// Each tap must be shorter than this, and the gap between them smaller still —
   /// values a deliberate double-tap clears easily but a hold never does.
-  private let maxTapDuration: TimeInterval = 0.25
-  private let maxGapBetweenTaps: TimeInterval = 0.30
+  private let maxTapDuration: TimeInterval = 0.30
+  private let maxGapBetweenTaps: TimeInterval = 0.40
+  /// If the pointer travels more than this between the first tap and the trigger,
+  /// treat it as a move/resize drag (keyboard-only mode moves on mouse motion) and
+  /// not a double-tap.
+  private let maxPointerDrift: CGFloat = 12
 
   func updateSubscriptions() {
     teardown()
@@ -1309,23 +1315,27 @@ final class DoubleTapActionManager {
   }
 
   private func handlePress(_ config: Config, now: TimeInterval) {
-    // A held mouse button or an in-progress SwiftShift drag means this modifier
-    // press is the start of a gesture, not a tap.
-    guard NSEvent.pressedMouseButtons == 0, !ShortcutsManager.shared.hasActiveShortcut else {
+    // A held mouse button means this modifier press is the start of a click-drag
+    // gesture, not a tap. (We can't key off ShortcutsManager.hasActiveShortcut here:
+    // holding the Move/Resize modifier arms that flag immediately, before any drag.)
+    guard NSEvent.pressedMouseButtons == 0 else {
       tapStates[config.type] = nil
       return
     }
 
+    let location = NSEvent.mouseLocation
     let state = tapStates[config.type]
     if let firstPress = state?.firstPressAt,
        let firstRelease = state?.firstReleaseAt,
+       let firstLocation = state?.firstPressLocation,
        (firstRelease - firstPress) <= maxTapDuration,
-       (now - firstRelease) <= maxGapBetweenTaps {
+       (now - firstRelease) <= maxGapBetweenTaps,
+       distance(firstLocation, location) <= maxPointerDrift {
       var updated = state ?? TapState()
       updated.secondPressAt = now
       tapStates[config.type] = updated
     } else {
-      tapStates[config.type] = TapState(firstPressAt: now, firstReleaseAt: nil, secondPressAt: nil)
+      tapStates[config.type] = TapState(firstPressAt: now, firstPressLocation: location, firstReleaseAt: nil, secondPressAt: nil)
     }
   }
 
@@ -1334,8 +1344,8 @@ final class DoubleTapActionManager {
 
     if let secondPress = state.secondPressAt {
       tapStates[config.type] = nil
-      guard (now - secondPress) <= maxTapDuration else { return }
-      guard NSEvent.pressedMouseButtons == 0, !ShortcutsManager.shared.hasActiveShortcut else { return }
+      guard (now - secondPress) <= maxTapDuration, NSEvent.pressedMouseButtons == 0 else { return }
+      if let firstLocation = state.firstPressLocation, distance(firstLocation, NSEvent.mouseLocation) > maxPointerDrift { return }
       fire(config.action)
     } else if let firstPress = state.firstPressAt, state.firstReleaseAt == nil {
       if (now - firstPress) <= maxTapDuration {
@@ -1347,6 +1357,10 @@ final class DoubleTapActionManager {
     } else {
       tapStates[config.type] = nil
     }
+  }
+
+  private func distance(_ a: NSPoint, _ b: NSPoint) -> CGFloat {
+    hypot(a.x - b.x, a.y - b.y)
   }
 
   private func fire(_ action: WindowSnapAction) {

--- a/Swift Shift/src/Manager/ShortcutsManager.swift
+++ b/Swift Shift/src/Manager/ShortcutsManager.swift
@@ -1127,6 +1127,10 @@ final class WindowSnapActionRunner {
   private struct MaximizedRecord {
     let window: AXUIElement
     let restoreFrame: CGRect
+    /// The frame this window was maximized to, so a later change to the computed
+    /// target (Dock moves, resolution changes, tiling margins toggled) doesn't
+    /// make the window look "not maximized" and discard the true restore frame.
+    let maximizedFrame: CGRect
   }
 
   private var maximizedRecords: [MaximizedRecord] = []
@@ -1178,7 +1182,18 @@ final class WindowSnapActionRunner {
 
     maximizedRecords.removeAll { !WindowManager.isAlive(window: $0.window) }
     let recordIndex = maximizedRecords.firstIndex { CFEqual($0.window, window) }
-    let isMaximized = rectsApproximatelyEqual(current, maximizeTarget, tolerance: frameTolerance)
+
+    // Trust an existing record's own maximized frame over a freshly computed
+    // target: the screen's visible frame can change after a window was
+    // maximized (Dock moves, resolution changes, tiling margins toggled)
+    // without the window itself moving. Comparing against a drifted target
+    // would otherwise look like "not maximized" and discard the restore frame.
+    let isMaximized: Bool
+    if let recordIndex {
+      isMaximized = rectsApproximatelyEqual(current, maximizedRecords[recordIndex].maximizedFrame, tolerance: frameTolerance)
+    } else {
+      isMaximized = rectsApproximatelyEqual(current, maximizeTarget, tolerance: frameTolerance)
+    }
 
     if isMaximized, let recordIndex {
       let restoreFrame = maximizedRecords.remove(at: recordIndex).restoreFrame
@@ -1191,12 +1206,20 @@ final class WindowSnapActionRunner {
       animate(window, from: liveFrame, to: CGRect(origin: origin, size: size))
     } else {
       if let recordIndex { maximizedRecords.remove(at: recordIndex) }
-      maximizedRecords.append(MaximizedRecord(window: window, restoreFrame: current))
+      maximizedRecords.append(MaximizedRecord(window: window, restoreFrame: current, maximizedFrame: maximizeTarget))
       if maximizedRecords.count > maxRecords {
         maximizedRecords.removeFirst(maximizedRecords.count - maxRecords)
       }
       animate(window, from: liveFrame, to: maximizeTarget)
     }
+  }
+
+  /// Cancels any running maximize/restore glide, leaving the window wherever it
+  /// currently is. Call before starting a real move/resize gesture — both share
+  /// `AXWindowWriter`, and letting them overlap would resize the wrong window.
+  func cancelAnimation() {
+    animator?.cancel()
+    animator = nil
   }
 
   private func animate(_ window: AXUIElement, from start: CGRect, to target: CGRect) {
@@ -1426,9 +1449,18 @@ final class DoubleTapActionManager {
       let previouslyMatched = lastMatched[config.type] ?? false
       lastMatched[config.type] = matched
 
-      if matched && !previouslyMatched {
+      guard matched != previouslyMatched else { continue }
+
+      if matched {
         handlePress(config, now: now)
-      } else if !matched && previouslyMatched {
+      } else if currentFlags.isSuperset(of: config.flags) {
+        // The configured modifier(s) are still physically held; an unrelated
+        // modifier joined in (e.g. Move = ⌥ and Resize = ⌥⇧: pressing ⇧ while ⌥
+        // is down makes Move's exact-flags match go false). That's contamination,
+        // not a release — abort instead of counting it as the tap ending, or
+        // releasing ⌥ afterwards would fire a double-tap that never happened.
+        tapStates[config.type] = nil
+      } else {
         handleRelease(config, now: now)
       }
     }

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -152,10 +152,18 @@ class WindowManager {
         AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, (minimized ? kCFBooleanTrue : kCFBooleanFalse))
     }
 
-    /// Whether the AX reference still points at a live window.
+    /// Whether the AX reference still points at a live, responsive window.
+    /// Bounds the messaging timeout so a hung (not terminated) owning app can't
+    /// stall this for the full multi-second AX default — callers may probe
+    /// several stored references in a row. Any error, not just
+    /// `.invalidUIElement`, is treated as "not alive": a stored reference that
+    /// can't be read is no more useful than a dead one.
     static func isAlive(window: AXUIElement) -> Bool {
+        AXUIElementSetMessagingTimeout(window, 0.15)
         var value: CFTypeRef?
-        return AXUIElementCopyAttributeValue(window, kAXRoleAttribute as CFString, &value) != .invalidUIElement
+        let result = AXUIElementCopyAttributeValue(window, kAXRoleAttribute as CFString, &value)
+        AXUIElementSetMessagingTimeout(window, 0) // restore the global default
+        return result == .success
     }
 
     private static let enhancedUIAttribute = "AXEnhancedUserInterface" as CFString

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -158,6 +158,27 @@ class WindowManager {
         return AXUIElementCopyAttributeValue(window, kAXRoleAttribute as CFString, &value) != .invalidUIElement
     }
 
+    private static let enhancedUIAttribute = "AXEnhancedUserInterface" as CFString
+
+    /// Reads `AXEnhancedUserInterface` on the app owning `window`. Chromium/Electron
+    /// apps turn this on while an AX client is attached, which makes `kAXPosition` /
+    /// `kAXSize` writes slow and non-live — turning it off for the duration of an
+    /// animated resize keeps the motion smooth. Returns the app element plus whether
+    /// the attribute was on, so the caller can restore it afterwards.
+    static func enhancedUIState(forAppOf window: AXUIElement) -> (app: AXUIElement, wasEnabled: Bool)? {
+        var pid: pid_t = 0
+        guard AXUIElementGetPid(window, &pid) == .success, pid > 0 else { return nil }
+        let app = AXUIElementCreateApplication(pid)
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, enhancedUIAttribute, &value) == .success,
+              let value, CFGetTypeID(value) == CFBooleanGetTypeID() else { return (app, false) }
+        return (app, CFBooleanGetValue((value as! CFBoolean)))
+    }
+
+    static func setEnhancedUI(_ enabled: Bool, forApp app: AXUIElement) {
+        AXUIElementSetAttributeValue(app, enhancedUIAttribute, enabled ? kCFBooleanTrue : kCFBooleanFalse)
+    }
+
     /// Convert an AppKit global rect (origin bottom-left of the primary screen, y up)
     /// to the AX global rect used by `kAXPosition`/`kAXSize` (origin top-left, y down).
     /// The transform is its own inverse.

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -128,4 +128,90 @@ class WindowManager {
         let fixed = convertYCoordinateBecauseTheAreTwoFuckingCoordinateSystems(point: windowLocation)
         return WindowBounds(topLeft: fixed, topRight: NSPoint(x: fixed.x + windowSize.width, y: fixed.y), bottomLeft: NSPoint(x: fixed.x, y: fixed.y - windowSize.height), bottomRight: NSPoint(x: fixed.x + windowSize.width, y: fixed.y - windowSize.height))
     }
+
+    // MARK: - Maximize / minimize helpers
+
+    /// Full frame (AX top-left coordinate space) of a window, or nil if either read fails.
+    static func getFrame(window: AXUIElement) -> CGRect? {
+        guard let position = getPosition(window: window), let size = getSize(window: window) else { return nil }
+        return CGRect(origin: position, size: size)
+    }
+
+    /// Move + resize a window to an exact frame. Writes twice because some apps clamp
+    /// the position or size on the first pass (windows with size increments, or apps
+    /// that toggle `AXEnhancedUserInterface` while an AX client is attached).
+    @discardableResult
+    static func setFrame(window: AXUIElement, to frame: CGRect) -> Bool {
+        move(window: window, to: frame.origin)
+        _ = resize(window: window, to: frame.size, from: frame.origin, shouldMoveOrigin: true)
+        return resize(window: window, to: frame.size, from: frame.origin, shouldMoveOrigin: true)
+    }
+
+    @discardableResult
+    static func setMinimized(window: AXUIElement, _ minimized: Bool) -> AXError {
+        AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, (minimized ? kCFBooleanTrue : kCFBooleanFalse))
+    }
+
+    /// Whether the AX reference still points at a live window.
+    static func isAlive(window: AXUIElement) -> Bool {
+        var value: CFTypeRef?
+        return AXUIElementCopyAttributeValue(window, kAXRoleAttribute as CFString, &value) != .invalidUIElement
+    }
+
+    /// Convert an AppKit global rect (origin bottom-left of the primary screen, y up)
+    /// to the AX global rect used by `kAXPosition`/`kAXSize` (origin top-left, y down).
+    /// The transform is its own inverse.
+    static func axRect(fromAppKit rect: CGRect) -> CGRect {
+        guard let primary = NSScreen.screens.first else { return rect }
+        let primaryHeight = primary.frame.height
+        return CGRect(x: rect.origin.x,
+                      y: primaryHeight - rect.origin.y - rect.height,
+                      width: rect.width,
+                      height: rect.height)
+    }
+
+    /// Visible frame (menu bar and Dock excluded), in AX coordinates, of the screen
+    /// that holds the largest part of `axRect`.
+    static func screenAXVisibleFrame(containing axRect: CGRect) -> CGRect? {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { return nil }
+
+        var best: (screen: NSScreen, area: CGFloat)?
+        for screen in screens {
+            let frameAX = self.axRect(fromAppKit: screen.frame)
+            let intersection = frameAX.intersection(axRect)
+            let area = intersection.isNull ? 0 : intersection.width * intersection.height
+            if best == nil || area > best!.area {
+                best = (screen, area)
+            }
+        }
+
+        guard let chosen = best?.screen else { return nil }
+        return self.axRect(fromAppKit: chosen.visibleFrame)
+    }
+
+    /// The focused window of the frontmost app, used as a fallback when the cursor
+    /// is not over a window. Skips our own app and ignored apps.
+    static func getFocusedWindow() -> AXUIElement? {
+        let system = AXUIElementCreateSystemWide()
+
+        var appValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(system, kAXFocusedApplicationAttribute as CFString, &appValue) == .success,
+              let appValue, CFGetTypeID(appValue) == AXUIElementGetTypeID() else { return nil }
+        let app = appValue as! AXUIElement
+
+        var windowValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &windowValue) == .success,
+              let windowValue, CFGetTypeID(windowValue) == AXUIElementGetTypeID() else { return nil }
+        let window = windowValue as! AXUIElement
+
+        var pid: pid_t = 0
+        AXUIElementGetPid(window, &pid)
+        guard pid != NSRunningApplication.current.processIdentifier else { return nil }
+        if let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier,
+           PreferencesManager.isAppIgnored(bundleId) {
+            return nil
+        }
+        return window
+    }
 }

--- a/Swift Shift/src/Manager/WindowManager.swift
+++ b/Swift Shift/src/Manager/WindowManager.swift
@@ -191,6 +191,19 @@ class WindowManager {
                       height: rect.height)
     }
 
+    /// Point inset to leave around a maximized window when macOS's own
+    /// "Tiled windows have margins" setting is on (System Settings → Desktop & Dock).
+    /// Returns 0 when that setting is off or the OS predates window tiling.
+    static func tiledWindowMarginInset() -> CGFloat {
+        guard #available(macOS 15.0, *) else { return 0 }
+        let enabled = UserDefaults(suiteName: "com.apple.WindowManager")?
+            .object(forKey: "EnableTiledWindowMargins") as? Bool ?? true
+        return enabled ? tiledWindowMargin : 0
+    }
+
+    /// Gap macOS leaves between a tiled window and the screen edges (~8 pt).
+    private static let tiledWindowMargin: CGFloat = 8
+
     /// Visible frame (menu bar and Dock excluded), in AX coordinates, of the screen
     /// that holds the largest part of `axRect`.
     static func screenAXVisibleFrame(containing axRect: CGRect) -> CGRect? {

--- a/Swift Shift/src/View/PreferencesView.swift
+++ b/Swift Shift/src/View/PreferencesView.swift
@@ -37,6 +37,7 @@ struct PreferencesView: View {
   @AppStorage(PreferenceKey.useQuadrants.rawValue) private var useQuadrants = false
   @AppStorage(PreferenceKey.snapToWindows.rawValue) private var snapToWindows = true
   @AppStorage(PreferenceKey.doubleTapModifierActions.rawValue) private var doubleTapModifierActions = false
+  @AppStorage(PreferenceKey.doubleTapActionsSwapped.rawValue) private var doubleTapActionsSwapped = false
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
@@ -86,11 +87,26 @@ struct PreferencesView: View {
       PreferenceToggle(
         isOn: $doubleTapModifierActions,
         title: "Double-tap modifier keys",
-        subtitle: "Resize key maximizes · Move key minimizes",
+        subtitle: doubleTapActionsSwapped
+          ? "Move key maximizes · Resize key minimizes"
+          : "Resize key maximizes · Move key minimizes",
         icon: "hand.tap"
       )
       .onChange(of: doubleTapModifierActions) { _ in
         DoubleTapActionManager.shared.updateSubscriptions()
+      }
+
+      if doubleTapModifierActions {
+        PreferenceToggle(
+          isOn: $doubleTapActionsSwapped,
+          title: "Swap double-tap actions",
+          subtitle: "Maximize on the Move key, minimize on the Resize key",
+          icon: "arrow.left.arrow.right"
+        )
+        .onChange(of: doubleTapActionsSwapped) { _ in
+          DoubleTapActionManager.shared.updateSubscriptions()
+        }
+        .padding(.leading, 26)
       }
     }
   }

--- a/Swift Shift/src/View/PreferencesView.swift
+++ b/Swift Shift/src/View/PreferencesView.swift
@@ -36,6 +36,7 @@ struct PreferencesView: View {
   @AppStorage(PreferenceKey.focusOnApp.rawValue) private var focusOnApp = true
   @AppStorage(PreferenceKey.useQuadrants.rawValue) private var useQuadrants = false
   @AppStorage(PreferenceKey.snapToWindows.rawValue) private var snapToWindows = true
+  @AppStorage(PreferenceKey.doubleTapModifierActions.rawValue) private var doubleTapModifierActions = false
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
@@ -81,6 +82,16 @@ struct PreferencesView: View {
         subtitle: "Add resistance near window edges",
         icon: "macwindow.on.rectangle"
       )
+
+      PreferenceToggle(
+        isOn: $doubleTapModifierActions,
+        title: "Double-tap modifier keys",
+        subtitle: "Resize key maximizes · Move key minimizes",
+        icon: "hand.tap"
+      )
+      .onChange(of: doubleTapModifierActions) { _ in
+        DoubleTapActionManager.shared.updateSubscriptions()
+      }
     }
   }
 }

--- a/SwiftShiftTests/WindowManagerTests.swift
+++ b/SwiftShiftTests/WindowManagerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AppKit
 @testable import Swift_Shift_Dev
 
 final class WindowManagerTests: XCTestCase {
@@ -79,6 +80,38 @@ final class WindowManagerTests: XCTestCase {
         XCTAssertEqual(bounds.bottomLeft.y, displayHeight, accuracy: 0.01)
         XCTAssertEqual(bounds.bottomRight.x, 0, accuracy: 0.01)
         XCTAssertEqual(bounds.bottomRight.y, displayHeight, accuracy: 0.01)
+    }
+
+    // MARK: - AX rect conversion (maximize helpers)
+
+    func testAxRectFromAppKit_preservesXAndSize() {
+        let appKit = CGRect(x: 120, y: 80, width: 640, height: 400)
+        let ax = WindowManager.axRect(fromAppKit: appKit)
+
+        XCTAssertEqual(ax.origin.x, appKit.origin.x, accuracy: 0.01)
+        XCTAssertEqual(ax.width, appKit.width, accuracy: 0.01)
+        XCTAssertEqual(ax.height, appKit.height, accuracy: 0.01)
+    }
+
+    func testAxRectFromAppKit_isItsOwnInverse() {
+        let appKit = CGRect(x: 33, y: 210, width: 500, height: 300)
+        let roundTrip = WindowManager.axRect(fromAppKit: WindowManager.axRect(fromAppKit: appKit))
+
+        XCTAssertEqual(roundTrip.origin.x, appKit.origin.x, accuracy: 0.01)
+        XCTAssertEqual(roundTrip.origin.y, appKit.origin.y, accuracy: 0.01)
+        XCTAssertEqual(roundTrip.width, appKit.width, accuracy: 0.01)
+        XCTAssertEqual(roundTrip.height, appKit.height, accuracy: 0.01)
+    }
+
+    func testAxRectFromAppKit_flipsYRelativeToPrimaryHeight() throws {
+        guard let primaryHeight = NSScreen.screens.first?.frame.height else {
+            throw XCTSkip("No screen available in the test host")
+        }
+        let appKit = CGRect(x: 0, y: 0, width: 200, height: 100)
+        let ax = WindowManager.axRect(fromAppKit: appKit)
+
+        // AppKit origin bottom-left → AX origin top-left: y = H - originY - height
+        XCTAssertEqual(ax.origin.y, primaryHeight - 100, accuracy: 0.01)
     }
 
     // MARK: - Window Bounds Structure


### PR DESCRIPTION
## What

Opt-in **"Double-tap modifier keys"** preference. With a modifier-only Move/Resize shortcut:

- Double-tap **Resize** → maximize the window under the cursor (a second tap restores).
- Double-tap **Move** → minimize to the Dock.
- **"Swap double-tap actions"** flips which key does which.

Targets the window under the cursor, falling back to the focused window; respects ignored apps. The maximize/restore transition is animated (~0.18s ease-out) and honors macOS's "Tiled windows have margins" setting (8pt edge gap when on).

## Why

SwiftShift is mouse-driven. This adds a keyboard path for the two most common window actions with no new hotkey — it reuses the already-configured modifier (Resize → size, Move → sends the window away).

## How

`DoubleTapActionManager` watches `.flagsChanged` with a press/release state machine. A hold-drag never registers: both taps must be short (< 0.30s), close together (< 0.40s), no mouse button held, pointer barely moving. `WindowSnapActionRunner` performs the action, keeping a bounded history of pre-maximize frames for restore. `WindowFrameAnimator` interpolates the frame through the existing `AXWindowWriter` queue and disables `AXEnhancedUserInterface` for smooth motion on Electron apps. New `WindowManager` helpers cover frame get/set, minimize, geometry, and tiling margins. Wired into lifecycle and shortcut save/delete like `MouseChordActionManager`.

Only modifier-only shortcuts are supported. "Maximize" = the visible frame, not native fullscreen.

## Tests

`xcodebuild test` green, 53 tests including new coordinate-conversion tests. Timing and animation verified manually.

## Try it

Enable the preference, set Move/Resize to modifier-only shortcuts, hover a window, double-tap either modifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
